### PR TITLE
Add osfamily to datasource hierarchy

### DIFF
--- a/files/hiera.agent.yaml
+++ b/files/hiera.agent.yaml
@@ -7,4 +7,5 @@
 
 :hierarchy:
   - "%{clientcert}"
+  - "%{osfamily}"
   - defaults


### PR DESCRIPTION
This will allow students to create a cross platform hierarchy for
Windows in Fundamentals.

Related to #COURSES-796