### PR TITLE
push classroom manifest out to all agents

### DIFF
--- a/files/site.pp
+++ b/files/site.pp
@@ -25,9 +25,6 @@ filebucket { 'main':
 # Make filebucket 'main' the default backup location for all File resources:
 File { backup => 'main' }
 
-# Specify a default value for the allow_virtual attribute on Packages.
-Package { allow_virtual => true }
-
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
 # http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
@@ -44,4 +41,3 @@ node default {
   #   class { 'my_class': }
   notify { "Hello ${fqdn}": }
 }
-

--- a/manifests/agent/workdir.pp
+++ b/manifests/agent/workdir.pp
@@ -52,6 +52,12 @@ define classroom::agent::workdir (
         replace => false,
       }
 
+      file { "${workdir}/manifests/classroom.pp":
+        ensure  => file,
+        source  => 'puppet:///modules/classroom/classroom.pp',
+        replace => false,
+      }
+
       # https://docs.puppetlabs.com/puppet/latest/reference/environments_configuring.html#environmenttimeout
       # suggests that this setting can be pushed up to puppet.conf globally.
       # Initial testing appears to confirm that. If this proves problematic, then


### PR DESCRIPTION
This puts the classroom manifest on agents, which will set the choco
provider, allow virtual, ignore source permissions, all that jazz as
necessary.

Fixes #TRAINTECH-64 and a handful of courseware issues.