### PR TITLE
Enable git colors on the command line for the root user

### DIFF
--- a/manifests/agent/git.pp
+++ b/manifests/agent/git.pp
@@ -66,4 +66,10 @@ class classroom::agent::git {
     unless  => 'git config --global user.email',
     require => Exec['generate_key'],
   }
+
+  exec { 'git config --global color.ui always':
+    unless  => 'git config --global color.ui',
+    require => Exec['generate_key'],
+  }
+
 }


### PR DESCRIPTION
This PR turns on colors for git from the command line. A student in a class asked why his session wasn't showing colors for `git status`, and said that the colors really helped with quickly seeing what was going on with git.
Hopefully, enabling colors will make git a little easier to grok for non-git users.

....plus, colors are pretty.