### PR TITLE
fix logic inversion and potentially ignored class -- causes puppet runs to take 7+ minutes on affected systems

### DIFF
--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -12,11 +12,10 @@ class classroom::repositories (
         false => '1',
       },
     }
-    # Don't choke if another module has "include epel"
-    if ! defined(Class['epel']) {
-      class { 'epel':
-        epel_enabled => $offline,
-      }
+    # Other classes *must not* define epel otherwise they can potentially 
+    # enable it which will potentially break offline classes
+    class { 'epel':
+      epel_enabled => ! $offline,
     }
   }
 


### PR DESCRIPTION
# Problem
One of our training partners encountered a bug with his classroom today while onsite for private training at a site with proxied internet access (AKA no internet).

Puppet run starts but freezes with no visible load or log messages on the host.  Eventually, after about 10 minutes or so, the run ends normally but subsequent runs still take 10 minutes each with no visible activity.

# Steps to reproduce
1. Disable outbound internet access:
```
/sbin/iptables -A OUTPUT -p tcp --destination-port 80 -j DROP
/sbin/iptables -A OUTPUT -p tcp --destination-port 443 -j DROP
```
2. Classify node with `classroom::course::fundamentals` and commit changes
3. Run puppet on the master `puppet agent -t`
This resulted in puppet hanging at the following points:
* around the time the message "yum repo" is printed during the initial post-classification puppet run
* after "applying configuration version" (this is the exact problem the partner was having)

# Diagnosis
Epel repository was enabled and this had broken the yum command for each puppet run.  This was confirmed by inspecting the output of `ps -eaf | grep yum` for hung processes:
```
root     11746     1  0 00:14 ?        00:00:00 /usr/bin/python /opt/puppet/lib/ruby/site_ruby/1.9.1/puppet/provider/package/yumhelper.py
```
# Root cause -- `classroom::repositories` class
1.  `epel` class parameter `epel_enabled` is inverted
2. The if statement around the above class resource means the `epel_enabled` parameter can potentially be ignored

# Proposed fixes
1. Invert the value of `$offline` before passing to `epel_enabled`
2. Remove the if statement - we can't have the `epel_enabled` directive be ignored.  Those using epel elsewhere need to take corrective action