### PR TITLE
Commit stash

### DIFF
--- a/files/pre-commit
+++ b/files/pre-commit
@@ -7,7 +7,10 @@ if [ $? -ne 0 ]; then exit 0; fi
 # first stash any on-disk changes so we're actually validating
 # what's staged to be committed and not just what's on disk.
 git diff --full-index --binary > /tmp/stash.$$
-git stash -q --keep-index
+if [[ -s /tmp/stash.$$ ]]
+then
+  git stash -q --keep-index
+fi
 
 EXITCODE=0
 for file in `git diff-index --cached --diff-filter=AM --name-only HEAD`

--- a/files/pre-commit
+++ b/files/pre-commit
@@ -4,12 +4,14 @@
 git show > /dev/null 2>&1
 if [ $? -ne 0 ]; then exit 0; fi
 
-# first stash any on-disk changes so we're actually validating
-# what's staged to be committed and not just what's on disk.
-git diff --full-index --binary > /tmp/stash.$$
+# Manually stash working changes
+git diff --binary > /tmp/stash.$$
+
 if [[ -s /tmp/stash.$$ ]]
 then
-  git stash -q --keep-index
+  STASH_EXISTS=true
+else
+  STASH_EXISTS=false
 fi
 
 EXITCODE=0
@@ -38,7 +40,7 @@ then
   echo "################################################################"
   echo -e "### \033[31mPlease fix the errors above before committing your code.\033[0m ###"
   echo "################################################################"
-  if [[ -s /tmp/stash.$$ ]]
+  if $STASH_EXISTS
   then
     echo "###                                                          ###"
     echo -e "###     \033[31mDid you remember to git add your updated code?\033[0m       ###"
@@ -48,10 +50,10 @@ then
   echo
 fi
 
-# now recover diffs to get back to pre commit state if needed.
-if [[ -s /tmp/stash.$$ ]]
+# Now recover the working files
+if $STASH_EXISTS
 then
-  git apply --whitespace=nowarn < /tmp/stash.$$ && git stash drop -q
+  git apply --whitespace=nowarn < /tmp/stash.$$
   rm /tmp/stash.$$
 fi
 

--- a/files/pre-commit
+++ b/files/pre-commit
@@ -54,8 +54,10 @@ fi
 if $STASH_EXISTS
 then
   git apply --whitespace=nowarn < /tmp/stash.$$
-  rm /tmp/stash.$$
 fi
+
+# Delete the stash even if it's empty
+rm /tmp/stash.$$
 
 exit $EXITCODE
 


### PR DESCRIPTION
I took out the stashing because it seems like that was breaking things.  The staged files will get dropped back in without popping the stash when the commit fails, so I think that was redundant.

Now what happens is that working dir changes are saved in /tmp/stash.whatever and the staged changes are still checked for syntax.  If something goes wrong, the staged changes stay around and the working dir changes git applied from the /tmp/stash.whatever.

Please test this out for edge cases before merging.