### PR TITLE
Drop unreliable test

### DIFF
--- a/manifests/master/student_environment.pp
+++ b/manifests/master/student_environment.pp
@@ -12,39 +12,37 @@ class classroom::master::student_environment inherits classroom::params {
     mode  => '0644',
   }
 
-  # we need this check because the $environmentpath doesn't exist until the
-  # node is classified as a PE Master, so we can't put files into it.
-  if defined(Class['puppet_enterprise::profile::master']) {
-    file { [
-      $environment,
-      "${environment}/manifests",
-      "${environment}/modules",
-    ]:
-      ensure => directory,
-    }
+  # This depends on the classroom setup script to ensure the existence of the
+  # environments directory.
+  file { [
+    $environment,
+    "${environment}/manifests",
+    "${environment}/modules",
+  ]:
+    ensure => directory,
+  }
 
-    file { "${environment}/manifests/site.pp":
-      ensure  => file,
-      source  => 'puppet:///modules/classroom/site.pp',
-      replace => false,
-    }
+  file { "${environment}/manifests/site.pp":
+    ensure  => file,
+    source  => 'puppet:///modules/classroom/site.pp',
+    replace => false,
+  }
 
-    # Ensure the environment cache is disabled and restart if needed
-    ini_setting {'environment_timeout':
-      ensure  => present,
-      path    => '/etc/puppetlabs/puppet/puppet.conf',
-      section => 'main',
-      setting => 'environment_timeout',
-      value   => '0',
-    }
+  # Ensure the environment cache is disabled and restart if needed
+  ini_setting {'environment_timeout':
+    ensure  => present,
+    path    => '/etc/puppetlabs/puppet/puppet.conf',
+    section => 'main',
+    setting => 'environment_timeout',
+    value   => '0',
+  }
 
-    # Ensure the environmentpath is configured and restart if needed
-    ini_setting {'environmentpath':
-      ensure  => present,
-      path    => '/etc/puppetlabs/puppet/puppet.conf',
-      section => 'main',
-      setting => 'environmentpath',
-      value   => $environmentpath,
-    }
+  # Ensure the environmentpath is configured and restart if needed
+  ini_setting {'environmentpath':
+    ensure  => present,
+    path    => '/etc/puppetlabs/puppet/puppet.conf',
+    section => 'main',
+    setting => 'environmentpath',
+    value   => $environmentpath,
   }
 }


### PR DESCRIPTION
This check was parse order dependent. It usually worked, but not always.
Instead, the PR at https://github.com/puppetlabs/puppetlabs-training-bootstrap/pull/522
creates the directory during classroom setup.

IMPORTANT: This should not be merged until that PR is merged -and-
released by at least a week.

Fixes #TRAINVM-201