### PR TITLE
Add rudimentary tuning class

### DIFF
--- a/files/hiera.master.yaml
+++ b/files/hiera.master.yaml
@@ -11,3 +11,4 @@
   - "environments/%{environment}/hieradata/%{clientcert}"
   - "environments/%{environment}/hieradata/defaults"
   - teams
+  - tuning

--- a/manifests/master/tuning.pp
+++ b/manifests/master/tuning.pp
@@ -1,0 +1,62 @@
+class classroom::master::tuning (
+  $jruby_purge         = $classroom::params::jruby_purge,
+  $jvm_tuning_profile  = $classroom::params::jvm_tuning_profile,
+) inherits classroom::params {
+
+  # See https://tickets.puppetlabs.com/browse/PE-9704
+  if $jruby_purge {
+    $cert   = '/etc/puppetlabs/puppet/ssl/certs/pe-internal-classifier.pem'
+    $key    = '/etc/puppetlabs/puppet/ssl/private_keys/pe-internal-classifier.pem'
+    $cacert = '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+    $master = 'https://master.puppetlabs.vm:8140'
+    $api    = 'puppet-admin-api/v1/jruby-pool'
+
+    cron { 'purge jruby pool':
+      ensure  => 'present',
+      command => "curl -i --cert ${cert} --key ${key} --cacert ${cacert} -X DELETE ${master}/${api}",
+      minute  => ['0', '30'],
+      target  => 'root',
+      user    => 'root',
+    }
+  }
+
+  if $jvm_tuning_profile != false {
+
+    case $jvm_tuning_profile {
+      'lvm': {
+        $amq_heap_mb                = '96'
+        $master_Xmx                 = '128m'
+        $master_Xms                 = '32m'
+        $master_MaxPermSize         = '96m'
+        $master_PermSize            = '96m'
+        $puppetdb_Xmx               = '64m'
+        $puppetdb_Xms               = '32m'
+        $console_Xmx                = '64m'
+        $console_Xms                = '32m'
+        $jruby_max_active_instances = 1
+        $delayed_job_workers        = 1
+      }
+      'minimal': {
+
+      }
+      'moderate': {
+
+      }
+      'aggressive': {
+
+      }
+      default : {
+        fail("Unknown tuning level, choose one of: 'lvm', 'minimal', 'moderate', 'aggressive', false")
+      }
+    }
+
+    file { '/etc/puppetlabs/puppet/hieradata/tuning.yaml':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('classroom/tuning.yaml.erb'),
+      before  => Class['puppet_enterprise::profile::master', 'puppet_enterprise::profile::console'],
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,11 +48,15 @@ class classroom::params {
 
   # list of module repositorites that should be precreated for the virtual courses
   $precreated_repositories = [ 'critical_policy', 'registry', 'profiles' ]
-  
+
   # Windows active directory setup parameters
   $ad_domainname           = 'CLASSROOM.local'
   $ad_netbiosdomainname    = 'CLASSROOM'
   $ad_dsrmpassword         = 'Puppetlabs1'
+
+  # Tuning parameters for classroom master performance
+  $jruby_purge        = false    # See https://tickets.puppetlabs.com/browse/PE-9704
+  $jvm_tuning_profile = false    # Set to 'lvm', 'minimal', 'moderate', 'aggressive', or false to disable
 
   # Certname and machine name from cert
   if is_domain_name("${::clientcert}") {
@@ -62,7 +66,7 @@ class classroom::params {
   else {
     $machine_name = $::clientcert
   }
-  
+
   # is this a student's tier3 agent in Architect?
   if $fqdn =~ /^\S+\.\S+\.puppetlabs\.vm$/ {
     $role = 'tier3'

--- a/templates/tuning.yaml.erb
+++ b/templates/tuning.yaml.erb
@@ -1,0 +1,16 @@
+---
+puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'
+puppet_enterprise::profile::amq::broker::heap_mb: '<%= @amq_heap_mb %>'
+puppet_enterprise::profile::master::java_args:
+  Xmx: '<%= @master_Xmx %>'
+  Xms: '<%= @master_Xms %>'
+  'XX:MaxPermSize': '=<%= @master_MaxPermSize %>'     <%# Yes, the weird extra equal sign is intentional %>
+  'XX:PermSize': '=<%= @master_PermSize %>'           <%# Yes, the weird extra equal sign is intentional %>
+puppet_enterprise::profile::puppetdb::java_args:
+  Xmx: '<%= @puppetdb_Xmx %>'
+  Xms: '<%= @puppetdb_Xms %>'
+puppet_enterprise::profile::console::java_args:
+  Xmx: '<%= @console_Xmx %>'
+  Xms: '<%= @console_Xms %>'
+puppet_enterprise::master::puppetserver::jruby_max_active_instances: <%= @jruby_max_active_instances %>
+puppet_enterprise::profile::console::delayed_job_workers: <%= @delayed_job_workers %>


### PR DESCRIPTION
* It can drop in a cron job to flush jruby instances every 30 minutes,
  on the advices of @cprice404 in https://tickets.puppetlabs.com/browse/PE-9704
* It can manage several tuning profiles for different levels of
  aggressiveness. To start with, only the profile used for the LVM is
  included.

Neither are enabled by default and the class isn't even included unless
we direct testers to try it out. I'd appreciate some benchmarks and
field testing, and I'd like @joshsamuelson to put together good numbers
to use for other tuning profiles.

After we have a better understanding of what the side effects may be, we
might include it by default.