### PR TITLE
Tuning hiera

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -155,5 +155,8 @@ class classroom::master (
 
     # Add any classes defined to the console
     classroom::console::class { $classes: }
+
+    # Add autoteam yaml
+    include classroom::master::autoteam
   }
 }

--- a/manifests/master/autoteam.pp
+++ b/manifests/master/autoteam.pp
@@ -1,0 +1,19 @@
+# Paramters:
+# * $autoteam: automatically create simple teams for Capstone. Defaults to false.
+#
+class classroom::master::autoteam (
+  $autoteam = $classroom::autoteam,
+) inherits classroom {
+  validate_bool($autoteam)
+
+  if $autoteam {
+    file { '/etc/puppetlabs/puppet/hieradata/teams.yaml':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('classroom/teams.yaml.erb'),
+      replace => false,
+    }
+  }
+}

--- a/manifests/master/hiera.pp
+++ b/manifests/master/hiera.pp
@@ -1,13 +1,8 @@
 # Make sure that Hiera is configured for the master so that we
 # enabling the use of Hiera within student environments.
 #
-# Paramters:
-# * $autoteam: automatically create simple teams for Capstone. Defaults to false.
 #
-class classroom::master::hiera (
-  $autoteam = $classroom::autoteam,
-) inherits classroom {
-  validate_bool($autoteam)
+class classroom::master::hiera {
 
   File {
     owner => 'root',
@@ -36,14 +31,4 @@ class classroom::master::hiera (
     source => 'puppet:///modules/classroom/hiera.master.yaml',
   }
 
-  if $autoteam {
-    file { '/etc/puppetlabs/puppet/hieradata/teams.yaml':
-      ensure  => file,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => template('classroom/teams.yaml.erb'),
-      replace => false,
-    }
-  }
 }

--- a/manifests/master/tuning.pp
+++ b/manifests/master/tuning.pp
@@ -3,6 +3,8 @@ class classroom::master::tuning (
   $jvm_tuning_profile  = $classroom::params::jvm_tuning_profile,
 ) inherits classroom::params {
 
+  include classroom::master::hiera
+
   # See https://tickets.puppetlabs.com/browse/PE-9704
   if $jruby_purge {
     $cert   = '/etc/puppetlabs/puppet/ssl/certs/pe-internal-classifier.pem'
@@ -57,6 +59,7 @@ class classroom::master::tuning (
       mode    => '0644',
       content => template('classroom/tuning.yaml.erb'),
       before  => Class['puppet_enterprise::profile::master', 'puppet_enterprise::profile::console'],
+      require => File['/etc/puppetlabs/puppet/hieradata/'],
     }
   }
 }


### PR DESCRIPTION
This removes the inherit classroom from hiera.pp since it was only used by the "autoteam.yaml" resource and splits that to a separate class.