### PR TITLE
Block concat 2.0.0 to prevent dependency error

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
     {"name":"hunner/wordpress",               "version_requirement":">= 0.6.0"},
     {"name":"jamtur01/irc",                   "version_requirement":">= 0.0.7"},
     {"name":"puppetlabs/apache",              "version_requirement":">= 1.1.1"},
-    {"name":"puppetlabs/concat",              "version_requirement":">= 1.0.4"},
+    {"name":"puppetlabs/concat",              "version_requirement":"< 2.0.0"},
     {"name":"puppetlabs/git",                 "version_requirement":">= 0.2.0"},
     {"name":"puppetlabs/haproxy",             "version_requirement":">= 1.0.0"},
     {"name":"puppetlabs/inifile",             "version_requirement":">= 1.0.0"},


### PR DESCRIPTION
concat-2.0.0 is causing negative dependency errors. Depend on `< 2.0.0`
in the classroom until that's sorted out, on the advice of @mhaskel 