### PR TITLE
Very minimal PE memory settings

### DIFF
--- a/manifests/master/tuning.pp
+++ b/manifests/master/tuning.pp
@@ -38,6 +38,8 @@ class classroom::master::tuning (
         $jruby_max_active_instances = 1
         $delayed_job_workers        = 1
       }
+      #Note: 'minimal' setting must be combined with
+      #      $jruby_purge=true
       'minimal': {
         $amq_heap_mb                = '32'
         $master_Xmx                 = '128m'

--- a/manifests/master/tuning.pp
+++ b/manifests/master/tuning.pp
@@ -40,17 +40,17 @@ class classroom::master::tuning (
       }
       'minimal': {
         if $jurby_purge {
-        $amq_heap_mb                = '32'
-        $master_Xmx                 = '128m'
-        $master_Xms                 = '128m'
-        $master_MaxPermSize         = '96m'
-        $master_PermSize            = '96m'
-        $puppetdb_Xmx               = '64m'
-        $puppetdb_Xms               = '64m'
-        $console_Xmx                = '64m'
-        $console_Xms                = '64m'
-        $jruby_max_active_instances = 1
-        $delayed_job_workers        = 1
+          $amq_heap_mb                = '32'
+          $master_Xmx                 = '128m'
+          $master_Xms                 = '128m'
+          $master_MaxPermSize         = '96m'
+          $master_PermSize            = '96m'
+          $puppetdb_Xmx               = '64m'
+          $puppetdb_Xms               = '64m'
+          $console_Xmx                = '64m'
+          $console_Xms                = '64m'
+          $jruby_max_active_instances = 1
+          $delayed_job_workers        = 1
         }
         else
         {

--- a/manifests/master/tuning.pp
+++ b/manifests/master/tuning.pp
@@ -16,7 +16,7 @@ class classroom::master::tuning (
     cron { 'purge jruby pool':
       ensure  => 'present',
       command => "curl -i --cert ${cert} --key ${key} --cacert ${cacert} -X DELETE ${master}/${api}",
-      minute  => ['0', '30'],
+      minute  => ['0','10','20','30','40','50'],
       target  => 'root',
       user    => 'root',
     }
@@ -39,6 +39,17 @@ class classroom::master::tuning (
         $delayed_job_workers        = 1
       }
       'minimal': {
+        $amq_heap_mb                = '32'
+        $master_Xmx                 = '128m'
+        $master_Xms                 = '128m'
+        $master_MaxPermSize         = '96m'
+        $master_PermSize            = '96m'
+        $puppetdb_Xmx               = '64m'
+        $puppetdb_Xms               = '64m'
+        $console_Xmx                = '64m'
+        $console_Xms                = '64m'
+        $jruby_max_active_instances = 1
+        $delayed_job_workers        = 1
       }
       'moderate': {
 

--- a/manifests/master/tuning.pp
+++ b/manifests/master/tuning.pp
@@ -38,9 +38,8 @@ class classroom::master::tuning (
         $jruby_max_active_instances = 1
         $delayed_job_workers        = 1
       }
-      #Note: 'minimal' setting must be combined with
-      #      $jruby_purge=true
       'minimal': {
+        if $jurby_purge {
         $amq_heap_mb                = '32'
         $master_Xmx                 = '128m'
         $master_Xms                 = '128m'
@@ -52,6 +51,11 @@ class classroom::master::tuning (
         $console_Xms                = '64m'
         $jruby_max_active_instances = 1
         $delayed_job_workers        = 1
+        }
+        else
+        {
+          fail("Minimal tuning profile requires `jruby_purge => true`.")
+        }
       }
       'moderate': {
 


### PR DESCRIPTION
This may be a bad idea, but I discovered that upping the jruby pool purge frequency to every 10min keeps it from OOMing even with just 128mb.  

It would be worth load testing, but it works ok for a single agent.  It seems to be running ok in < 2GB on the VM.