### PR TITLE
Recover CWD after pre-commit hook

### DIFF
--- a/files/pre-commit
+++ b/files/pre-commit
@@ -52,5 +52,7 @@ then
   rm /tmp/stash.$$
 fi
 
+# I don't know why, but somehow we're losing CWD and this gets it back
+cd .
 exit $EXITCODE
 


### PR DESCRIPTION
I'm not completely certain why the stash & pop sometimes loses the CWD.
It has something to do with the order that files are created and
checked, etc. In any case, this *should* recover it.

Preliminary testing shows this to be effective. I will update this PR if
the problem has been completely resolved by end of class.