### PR TITLE
Remove filebackup configuration to mitigate issue

### DIFF
--- a/files/site.pp
+++ b/files/site.pp
@@ -1,29 +1,13 @@
 ## site.pp ##
 
-# This file (/etc/puppetlabs/puppet/manifests/site.pp) is the main entry point
-# used when an agent connects to a master and asks for an updated configuration.
+# This file ($environment/manifests/site.pp) is the main entry point used
+# when an agent connects to a master and asks for an updated configuration.
 #
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
 # http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
 # node definitions.)
-
-## Active Configurations ##
-
-# PRIMARY FILEBUCKET
-# This configures puppet agent and puppet inspect to back up file contents when
-# they run. The Puppet Enterprise console needs this to display file contents
-# and differences.
-
-# Define filebucket 'main':
-filebucket { 'main':
-  server => 'master.puppetlabs.vm',
-  path   => false,
-}
-
-# Make filebucket 'main' the default backup location for all File resources:
-File { backup => 'main' }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See


### PR DESCRIPTION
If the agent specifies an environment, filebackup fails, causing the
file to not be managed and the run to fail and all kinds of bad things.
We expect some students to set the environment to avoid the override
warning, so we'll just disable filebucket so their runs succeed.

https://tickets.puppetlabs.com/browse/PUP-4954

I should clarify that for simplicity, this is being made to student environments only--because if they're running against production, this bug doesn't hit.