### PR TITLE
Corrects the agent tarball download.

### DIFF
--- a/manifests/master/agent_tarball.pp
+++ b/manifests/master/agent_tarball.pp
@@ -7,26 +7,43 @@ class classroom::master::agent_tarball {
   $cachedir  = $classroom::params::cachedir
   $publicdir = $classroom::params::publicdir
 
-  if versioncmp($::pe_version, '3.4.0') >= 0 {
-    $filename = "puppet-enterprise-${version}-${::platform_tag}-agent.tar.gz"
-    $download = "https://pm.puppetlabs.com/puppet-enterprise/${version}/${filename}"
+  if versioncmp($version, '2015.2.0') >= 0 {
+    # https://pm.puppetlabs.com/puppet-agent/2015.2.0/1.2.2/repos/puppet-agent-el-6-x86_64.tar.gz
+    $filename    = "puppet-agent-${::platform_tag}.tar.gz"
+    $download    = "https://pm.puppetlabs.com/puppet-agent/${version}/${aio_agent_version}/repos/${filename}"
+    $destination = "${publicdir}/${version}/${aio_agent_version}/repos"
+  }
+  elsif versioncmp($version, '3.4.0') >= 0 {
+    # https://pm.puppetlabs.com/puppet-enterprise/3.8.0/puppet-enterprise-3.8.0-el-6-x86_64-agent.tar.gz
+    $filename    = "puppet-enterprise-${version}-${::platform_tag}-agent.tar.gz"
+    $download    = "https://pm.puppetlabs.com/puppet-enterprise/${version}/${filename}"
+    $destination = "${publicdir}/${version}"
+  }
+  else {
+    fail("Cannot retrieve agent tarball for unsupported PE version ${version}")
+  }
 
-    file { [$publicdir, "${publicdir}/${version}"]:
-      ensure => directory,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0755',
-    }
+  dirtree { $destination:
+    path    => $destination,
+    ensure  => present,
+    parents => true,
+  }
 
-    pe_staging::file { "${cachedir}/${filename}":
-      source => $download,
-      target => "${cachedir}/${filename}",
-      before => File["${publicdir}/${version}/${filename}"],
-    }
+  file { $destination:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
 
-    file { "${publicdir}/${version}/${filename}":
-      ensure => file,
-      source => "${cachedir}/${filename}",
-    }
+  pe_staging::file { "${cachedir}/${filename}":
+    source => $download,
+    target => "${cachedir}/${filename}",
+    before => File["${destination}/${filename}"],
+  }
+
+  file { "${destination}/${filename}":
+    ensure => file,
+    source => "${cachedir}/${filename}",
   }
 }


### PR DESCRIPTION
This has been well tested with 2015.2 and I've verified that the
download url & file path are the the same as they used to be under 3.8