### PR TITLE
(TRAINVM-227) trust the master's CA cert

### DIFF
--- a/files/classroom.pp
+++ b/files/classroom.pp
@@ -1,9 +1,6 @@
 # Cut down on agent output noise.
 Package { allow_virtual => true }
 
-# dirty hack to allow student masters to download the agent tarball in Architect
-Pe_staging::File { curl_option => '-k' }
-
 # top level tweaks for windows
 if $::osfamily == windows {
   # default package provider

--- a/manifests/cacert.pp
+++ b/manifests/cacert.pp
@@ -1,0 +1,15 @@
+class classroom::cacert {
+  assert_private('This class should not be called directly')
+
+  file { '/etc/pki/ca-trust/source/anchors/classroom.crt':
+    ensure => file,
+    source => "${classroom::confdir}/ssl/certs/ca.pem",
+    notify => Exec['trust classroom ca'],
+  }
+
+  exec { 'trust classroom ca':
+    command     => '/usr/bin/update-ca-trust extract',
+    onlyif      => '/usr/bin/update-ca-trust enable',
+    refreshonly => true,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,9 @@ class classroom (
 
   include classroom::repositories
 
+  # trust classroom CA so students can download from the master
+  include classroom::cacert
+
   # temporary compatibility shim for PE 3.x
   include classroom::compatibility
 }


### PR DESCRIPTION
This allows curl to work without hacks and also allows the pe_repo
pe_http_status_code() function to work properly.