### PR TITLE
Adds metrics scripts for the Architect class

### DIFF
--- a/files/metrics/metrics/list_all_metrics.rb
+++ b/files/metrics/metrics/list_all_metrics.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+#memory = client["java.lang:type=Memory"]
+#puts memory.attributes
+
+metric_names = client.query_names
+metric_names.each do |metric_name|
+   puts "Metric Name Class: #{metric_name.class}"
+   puts "Metric Name toString: #{metric_name}"
+   puts "Metric Domain: #{metric_name.domain}"
+   puts "Metric Properties: #{metric_name.key_property_list_string}"
+   puts
+end

--- a/files/metrics/metrics/list_all_puppet_metrics.rb
+++ b/files/metrics/metrics/list_all_puppet_metrics.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+metric_names = client.query_names("metrics:*")
+metric_names.each do |metric_name|
+   name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")
+   if name_property.start_with?("puppetlabs.")
+      puts name_property
+      mbean = client[metric_name]
+      mbean.attributes.each do |attribute|
+         puts "\t#{attribute}: #{mbean[attribute]}"
+      end
+      puts
+   end
+end

--- a/files/metrics/metrics/puppet_function_stats.rb
+++ b/files/metrics/metrics/puppet_function_stats.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+require 'table_print'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+metric_names = client.query_names("metrics:*")
+functions = []
+metric_names.each do |metric_name|
+   name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")
+   if match = name_property.match(/^puppetlabs\..*functions\.(.*)$/)
+      mbean = client[metric_name]
+      fname = match[1]
+      mean = mbean["Mean"].nan? ? 0 : mbean["Mean"]
+      count = mbean["Count"]
+      functions << {:name => fname,
+                    :mean => mean.round(2),
+                    :count => count,
+                    :aggregate => (mean * count).round(2)}
+   end
+end
+
+sorted_functions = functions.sort_by { |v| - v[:aggregate] }
+
+puts
+puts "Function calls, sorted by total CPU time spent (in ms)"
+puts
+
+tp sorted_functions, :name, :aggregate, :count, :mean
+
+puts

--- a/files/metrics/metrics/puppet_http_stats.rb
+++ b/files/metrics/metrics/puppet_http_stats.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+require 'table_print'
+
+MetricsId = ARGV.first.gsub(".#{`facter domain`.chomp}", '')
+
+def client
+   @client ||= JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+end
+
+def metric_name(name)
+  if name =~ /\A[\w.-]+\z/
+    "metrics:name=puppetlabs.#{MetricsId}.#{name}"
+  else
+    "metrics:name=\"puppetlabs.#{MetricsId}.#{name}\""
+  end
+end
+
+def metric(name)
+   client[metric_name(name)]
+end
+
+def canonical(name)
+  if ['total', 'other', 'active' ].include? name
+    name
+  else
+    "puppet-v3-#{name}-/\\*/"
+  end
+end
+
+def request_count_info(request_type)
+   mbean = metric("http.#{canonical(request_type)}-requests")
+   mean = mbean["Mean"].nan? ? 0 : mbean["Mean"]
+   count = mbean["Count"]
+   {:name => request_type,
+    :mean => mean.round(2),
+    :count => count,
+    :aggregate => (mean * count).round(2)}
+end
+
+def request_info(request_type, total)
+   req_count_info = request_count_info(request_type)
+   perc_count = (metric("http.#{canonical(request_type)}-percentage")["Value"] * 100).round(2)
+   perc_time = ((req_count_info[:aggregate] / total[:aggregate]) * 100).round(2)
+   req_count_info[:perc_count] = perc_count
+   req_count_info[:perc_time] = perc_time
+   req_count_info
+end
+
+puts
+
+num_cpus = metric("num-cpus")["Value"]
+active = metric("http.active-requests")["Count"]
+active_histo = metric("http.active-histo")
+
+puts "Active Request Statistics"
+puts "------------------------------------"
+puts "Num CPUs: #{num_cpus}"
+puts "Current Active Requests: #{active}"
+puts "Average Num Active Requests: #{active_histo["Mean"]}"
+puts
+
+total = request_count_info("total")
+total[:perc_count] = 100
+total[:perc_time] = 100
+request_counts = []
+request_counts << total
+request_counts << request_info("catalog", total)
+request_counts << request_info("node", total)
+request_counts << request_info("report", total)
+request_counts << request_info("other", total)
+request_counts << request_info("file_metadatas", total)
+request_counts << request_info("file_metadata", total)
+request_counts << request_info("file_content", total)
+
+puts "Request Statistics (time spent in ms; percentage of total requests, etc.)"
+puts
+
+ratios = request_counts.sort_by { |r| - r[:aggregate] }
+tp ratios, :name, :aggregate, :count, :mean, :perc_count, :perc_time
+
+puts

--- a/files/metrics/metrics/puppet_resource_eval_stats.rb
+++ b/files/metrics/metrics/puppet_resource_eval_stats.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+require 'table_print'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+metric_names = client.query_names("metrics:*")
+resources = []
+metric_names.each do |metric_name|
+   name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")
+   if match = name_property.match(/^puppetlabs\..*compiler.evaluate_resource\.(.*)$/)
+      mbean = client[metric_name]
+      rname = match[1]
+      mean = mbean["Mean"].nan? ? 0 : mbean["Mean"]
+      count = mbean["Count"]
+      resources << {:name => rname,
+                    :mean => mean.round(2),
+                    :count => count,
+                    :aggregate => (mean * count).round(2)}
+   end
+end
+
+sorted_resources = resources.sort_by { |v| - v[:aggregate] }
+
+puts
+puts "Resource evaluations during compile, sorted by total CPU time spent (in ms)"
+puts
+
+tp.set :max_width, 60
+tp sorted_resources, :name, :aggregate, :count, :mean
+
+puts

--- a/files/metrics/puppetserver_compiles
+++ b/files/metrics/puppetserver_compiles
@@ -1,0 +1,17 @@
+#! /bin/sh
+
+LOG='/var/log/puppetlabs/puppetserver/puppetserver.log'
+DATE=$(date +"%Y-%m-%d")
+NOW=$(date +%H)
+
+echo "This is a very simple script that just greps the PuppetServer logs for"
+echo "catalog compiles, counts them, and collates them into an hour-by-hour"
+echo "list from last midnight to right now."
+echo
+
+for i in $(seq 0 ${NOW})
+do
+  num=$(printf "%02d" $i)
+  echo -n "${DATE} ${num}: "
+  grep 'Compiled catalog' ${LOG} | grep "${DATE} ${num}:" | wc -l
+done

--- a/files/metrics/puppetserver_metrics
+++ b/files/metrics/puppetserver_metrics
@@ -1,0 +1,42 @@
+#! /bin/sh
+
+PORT='9010'
+SCRIPTS='/usr/local/bin/metrics'
+JAVA='/opt/puppetlabs/server/bin/java'
+GEM_HOME='/opt/puppetlabs/server/data/puppetserver/jruby-gems'
+CLASSPATH='/opt/puppetlabs/server/apps/puppetserver/puppet-server-release.jar org.jruby.Main'
+
+while getopts ":l" opt; do
+  case $opt in
+    l)
+      SERVER=$(facter fqdn)
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: $0 [-l] <name of metric to display>"
+  echo
+  echo "Collect and display metrics from a running Puppet Master."
+  echo "This requires an unauthenticated JMX remote listening on port ${PORT}."
+  echo
+  echo "Pass -l to run against your local server. Defaults to classroom master."
+  echo
+  echo "Available metrics:"
+  for i in ${SCRIPTS}/*; do echo -e "\t* $(basename $i .rb)"; done
+  echo
+  exit 1
+fi
+
+METRIC=$(basename $1 .rb) # strip the extension, just in case
+[[ $SERVER ]] || SERVER=$(puppet master --configprint server)
+
+if [ -f "${JAVA}" ]; then
+  export GEM_HOME
+  exec ${JAVA} -cp ${CLASSPATH} ${SCRIPTS}/${METRIC}.rb ${SERVER} ${PORT}
+else
+  # run directly. Untested.
+  exec ${SCRIPTS}/${METRIC}.rb ${SERVER} ${PORT}
+fi

--- a/manifests/course/architect.pp
+++ b/manifests/course/architect.pp
@@ -26,6 +26,9 @@ class classroom::course::architect (
     include classroom::agent::hosts
 
     # set up graphite/grafana on the classroom master
+    include classroom::master::graphite
+
+    # include metrics tools for labs & demos
     include classroom::master::metrics
 
     # Configure the classroom so that any secondary masters will get the
@@ -40,6 +43,9 @@ class classroom::course::architect (
     # Include the Irssi setup and collect all hosts
     include classroom::agent::irc
     include classroom::agent::hosts
+
+    # include metrics tools for labs & demos
+    include classroom::master::metrics
 
     # The student masters should export a balancermember
     include classroom::master::balancermember

--- a/manifests/master/graphite.pp
+++ b/manifests/master/graphite.pp
@@ -1,0 +1,84 @@
+class classroom::master::graphite {
+  # Configure Graphite & Grafana
+  include '::apache'
+
+  ########## Grafana
+  class {'grafana':
+    graphite_host      => $::ipaddress,
+    elasticsearch_host => $::fqdn,
+    elasticsearch_port => 9200,
+  }
+
+  apache::vhost { $::fqdn:
+    servername      => $::fqdn,
+    port            => 9000,
+    docroot         => '/opt/grafana',
+    error_log_file  => 'grafana_error.log',
+    access_log_file => 'grafana_access.log',
+    directories     => [
+      {
+        path            => '/opt/grafana',
+        options         => [ 'None' ],
+        allow           => 'from All',
+        allow_override  => [ 'None' ],
+        order           => 'Allow,Deny',
+      }
+    ],
+    require => Class['grafana'],
+  }
+
+  ########## Graphite
+  file { '/opt/graphite':
+    ensure => 'directory',
+  }
+
+  apache::vhost { $::ipaddress:
+    port    => '80',
+    docroot => '/opt/graphite/webapp',
+    wsgi_application_group      => '%{GLOBAL}',
+    wsgi_daemon_process         => 'graphite',
+    wsgi_daemon_process_options => {
+      processes          => '5',
+      threads            => '5',
+      display-name       => '%{GROUP}',
+      inactivity-timeout => '120',
+    },
+    wsgi_import_script          => '/opt/graphite/conf/graphite.wsgi',
+    wsgi_import_script_options  => {
+      process-group     => 'graphite',
+      application-group => '%{GLOBAL}'
+    },
+    wsgi_process_group          => 'graphite',
+    wsgi_script_aliases         => {
+      '/' => '/opt/graphite/conf/graphite.wsgi'
+    },
+    headers => [
+      'set Access-Control-Allow-Origin "*"',
+      'set Access-Control-Allow-Methods "GET, OPTIONS, POST"',
+      'set Access-Control-Allow-Headers "origin, authorization, accept"',
+    ],
+    directories => [{
+      path => '/media/',
+      order => 'deny,allow',
+      allow => 'from all'}
+    ],
+    before => Class['graphite'],
+  }
+
+  class { 'graphite':
+    gr_web_server           => 'none',
+    gr_disable_webapp_cache => true,
+    gr_storage_schemas      => [
+      {
+        name       => 'carbon',
+        pattern    => '^carbon\.',
+        retentions => '1m:90d'
+      },
+      {
+        name       => 'default',
+        pattern    => '.*',
+        retentions => '1m:30m,1m:1d,5m:2y'
+      },
+    ],
+  }
+}

--- a/manifests/master/ircd.pp
+++ b/manifests/master/ircd.pp
@@ -23,10 +23,7 @@ class classroom::master::ircd {
   # gems used by the irc report handler.
   package { 'carrier-pigeon':
     ensure   => present,
-    provider => $::aio_agent_version ? {
-      undef   => pe_puppetserver_gem,
-      default => puppetserver_gem,
-    },
+    provider => $classroom::puppetserver_gem_provider,
   }
 
 }

--- a/manifests/master/metrics.pp
+++ b/manifests/master/metrics.pp
@@ -1,86 +1,34 @@
+# Create a few scripts for gathering metrics from a running server.
+# Requires java_args => {"Dcom.sun.management.jmxremote":"=true","Dcom.sun.management.jmxremote.port":"=9010","Dcom.sun.management.jmxremote.authenticate":"=false","Dcom.sun.management.jmxremote.local.only":"=false","Dcom.sun.management.jmxremote.ssl":"=false"}
 class classroom::master::metrics {
+  assert_private('This class should not be called directly')
 
-  # Configure Graphite & Grafana
-  include '::apache'
-
-  ########## Grafana
-  class {'grafana':
-    graphite_host      => $::ipaddress,
-    elasticsearch_host => $::fqdn,
-    elasticsearch_port => 9200,
+  File {
+    owner => 'root',
+    group => 'root',
+    mode  => '0777',
   }
 
-  apache::vhost { $::fqdn:
-    servername      => $::fqdn,
-    port            => 9000,
-    docroot         => '/opt/grafana',
-    error_log_file  => 'grafana_error.log',
-    access_log_file => 'grafana_access.log',
-    directories     => [
-      {
-        path            => '/opt/grafana',
-        options         => [ 'None' ],
-        allow           => 'from All',
-        allow_override  => [ 'None' ],
-        order           => 'Allow,Deny',
-      }
-    ],
-    require => Class['grafana'],
+  package { ['jmx', 'table_print']:
+    ensure   => present,
+    provider => $classroom::puppetserver_gem_provider,
   }
 
-
-  ########## Graphite
-  file { '/opt/graphite':
-    ensure => 'directory',
+  file { '/usr/local/bin/puppetserver_compiles':
+    ensure => file,
+    source => 'puppet:///modules/classroom/metrics/puppetserver_compiles',
   }
 
-  apache::vhost { $::ipaddress:
-    port    => '80',
-    docroot => '/opt/graphite/webapp',
-    wsgi_application_group      => '%{GLOBAL}',
-    wsgi_daemon_process         => 'graphite',
-    wsgi_daemon_process_options => {
-      processes          => '5',
-      threads            => '5',
-      display-name       => '%{GROUP}',
-      inactivity-timeout => '120',
-    },
-    wsgi_import_script          => '/opt/graphite/conf/graphite.wsgi',
-    wsgi_import_script_options  => {
-      process-group     => 'graphite',
-      application-group => '%{GLOBAL}'
-    },
-    wsgi_process_group          => 'graphite',
-    wsgi_script_aliases         => {
-      '/' => '/opt/graphite/conf/graphite.wsgi'
-    },
-    headers => [
-      'set Access-Control-Allow-Origin "*"',
-      'set Access-Control-Allow-Methods "GET, OPTIONS, POST"',
-      'set Access-Control-Allow-Headers "origin, authorization, accept"',
-    ],
-    directories => [{
-      path => '/media/',
-      order => 'deny,allow',
-      allow => 'from all'}
-    ],
-    before => Class['graphite'],
+  # JMX wrapper script that calls the actual metrics in the context of the JVM
+  file { '/usr/local/bin/puppetserver_metrics':
+    ensure => file,
+    source => 'puppet:///modules/classroom/metrics/puppetserver_metrics',
   }
-  class { 'graphite':
-    gr_web_server           => 'none',
-    gr_disable_webapp_cache => true,
-    gr_storage_schemas      => [
-    {
-      name       => 'carbon',
-      pattern    => '^carbon\.',
-      retentions => '1m:90d'
-    },
-    {
-      name       => 'default',
-      pattern    => '.*',
-      retentions => '1m:30m,1m:1d,5m:2y'
-    },
-  ],
 
+  # the individual JMX metrics called by the wrapper script
+  file { '/usr/local/bin/metrics':
+    ensure  => directory,
+    recurse => true,
+    source  => 'puppet:///modules/classroom/metrics/metrics',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,12 @@ class classroom::params {
     $codedir = '/etc/puppetlabs/code'
   }
 
+  # blerg
+  $puppetserver_gem_provider = $::aio_agent_version ? {
+      undef   => pe_puppetserver_gem,
+      default => puppetserver_gem,
+    }
+
   # default user password
   $password  = '$1$Tge1IxzI$kyx2gPUvWmXwrCQrac8/m0' # puppetlabs
   $consolepw = 'puppetlabs'


### PR DESCRIPTION
* `puppetserver_compiles`
  * counts catalog compiles hourly for the current day
* `puppetserver_metrics`
  * uses JMX to request and present various metrics from the server
  * can run against local or classroom master
  * requires `java_args` to enable JMX remote

puppet_enterprise::profile::master::java_args => {"Dcom.sun.management.jmxremote":"=true","Dcom.sun.management.jmxremote.port":"=9010","Dcom.sun.management.jmxremote.authenticate":"=false","Dcom.sun.management.jmxremote.local.only":"=false","Dcom.sun.management.jmxremote.ssl":"=false"}

Yes, the equal signs are intended and required.