### PR TITLE
Fixed ssh-keygen for RedHat machines.

### DIFF
--- a/manifests/agent/git.pp
+++ b/manifests/agent/git.pp
@@ -48,7 +48,11 @@ class classroom::agent::git {
   }
 
   exec { 'generate_key':
-    command => "bash.exe -c \"ssh-keygen -t rsa -N '' -f '${sshpath}/id_rsa'\"",
+    command = $::osfamily ? {
+      'windows' => "bash.exe -c \"ssh-keygen -t rsa -N '' -f '${sshpath}/id_rsa'\"",
+      'RedHat'  => "ssh-keygen -t rsa -N '' -f '${sshpath}/id_rsa'",
+      # no default should make catalog compilation fail on other OS families
+    }
     creates => "${sshpath}/id_rsa",
     require => File[$sshpath],
   }


### PR DESCRIPTION
This is an essential fix. 
This necessitates a new module release, since without the fix, ssh-keygen will fail on redhat machines, and we have trainings next week.
Apologies for the earlier commit that broke this.
@joshsamuelson - please review.