### PR TITLE
Replace Invoke-WebRequest with longer, but more compatible command

### DIFF
--- a/manifests/windows/geotrust.pp
+++ b/manifests/windows/geotrust.pp
@@ -2,13 +2,13 @@ class classroom::windows::geotrust {
   assert_private('This class should not be called directly')
 
   exec { 'download-geotrust-cert':
-    command  => 'Invoke-Webrequest https://www.geotrust.com/resources/root_certificates/certificates/GeoTrust_Global_CA.pem -outfile c:\windows\temp\GeoTrust_Glocal_CA.pem',
-    creates  => 'c:/windows/temp/GeoTrust_Glocal_CA.pem',
+    command  => '$wc = New-Object System.Net.WebClient;$wc.DownloadFile("https://www.geotrust.com/resources/root_certificates/certificates/GeoTrust_Global_CA.pem","C:\Windows\Temp\GeoTrust_Glocal_CA.pem")',
+    creates  => 'C:/Windows/Temp/GeoTrust_Glocal_CA.pem',
     provider => powershell,
     timeout  => $classroom::timeout,
   }
   exec { 'install-geotrust-cert':
-    command     => 'certutil -addstore root c:\windows\temp\GeoTrust_Glocal_CA.pem',
+    command     => 'certutil -addstore root C:\Windows\Temp\GeoTrust_Glocal_CA.pem',
     provider    => powershell,
     refreshonly => true,
     subscribe   => Exec['download-geotrust-cert'],


### PR DESCRIPTION
This commit swaps out the Invoke-WebRequest command with something that works in older versions of powershell as well, a System.Net.WebClient object.