### PR TITLE
Courses 1355/update hiera configurations

### DIFF
--- a/files/hiera/hiera.master.yaml
+++ b/files/hiera/hiera.master.yaml
@@ -8,6 +8,7 @@
 :hierarchy:
   - "%{clientcert}"
   - overrides
+  - "environments/%{environment}/hieradata/%{osfamily}"
   - "environments/%{environment}/hieradata/%{clientcert}"
   - "environments/%{environment}/hieradata/defaults"
   - teams

--- a/manifests/agent/hiera.pp
+++ b/manifests/agent/hiera.pp
@@ -40,7 +40,7 @@ class classroom::agent::hiera {
 
     file { "${classroom::workdir}/hiera.yaml":
       ensure  => file,
-      source  => 'puppet:///modules/classroom/hiera/hiera.agent.yaml',
+      content => template('classroom/hiera/hiera.agent.yaml.erb'),
       replace => false,
     }
 
@@ -53,7 +53,7 @@ class classroom::agent::hiera {
     # Because PE writes a default, we cannot use replace => false
     file { "${classroom::codedir}/hiera.yaml":
       ensure => file,
-      source => 'puppet:///modules/classroom/hiera/hiera.agent.yaml',
+      content => template('classroom/hiera/hiera.agent.yaml.erb'),
     }
   }
 

--- a/templates/hiera/hiera.agent.yaml.erb
+++ b/templates/hiera/hiera.agent.yaml.erb
@@ -3,7 +3,11 @@
   - yaml
 
 :yaml:
+<% if @kernel == 'windows' -%>
+  :datadir: C:\puppetcode\hieradata
+<% else -%>
   :datadir: /etc/puppetlabs/code/hieradata
+<% end -%>
 
 :hierarchy:
   - "%{clientcert}"


### PR DESCRIPTION
These commits do two things.
  * It adds a layer to the master's hiera.yaml so that it actually checks osfamily ... which is required so that labs work as expected.
  * It switches the agent's hiera.yaml file from a static linux-specific file, to one that changes datadir based on whether the machine is windows or not.