### PR TITLE
concurrent runs and safety checks

### DIFF
--- a/files/run_agents
+++ b/files/run_agents
@@ -30,6 +30,11 @@ For example:
         options[:mode] = :reset
     end
 
+    opts.on("-c [INTERVAL]", "--concurrent [INTERVAL]", Integer,
+            "Run agents concurrently. Specify interval between runs or default to 3.") do |opt|
+        options[:interval] = opt || 3
+    end
+
     opts.on("-i IDENTITY", "--identity IDENTITY", "Run the agent on the specified container.") do |opt|
         options[:identity] = opt
     end
@@ -52,7 +57,7 @@ end
 
 def reset(identity)
   puts "Removing certificates for #{identity}"
-  ssldir   = `puppet agent --configprint ssldir`.chomp
+  ssldir   = `docker exec #{identity} puppet agent --configprint ssldir`.chomp
   certname = `docker exec #{identity} puppet agent --configprint certname`.chomp
 
   system("docker exec #{identity} rm #{ssldir}/certs/#{certname}.pem")
@@ -63,7 +68,9 @@ def reset(identity)
   system("docker exec #{identity} puppet agent -t")
 end
 
-containers = `docker ps -q`.split
+def containers
+  `docker ps -q`.split
+end
 
 case options[:mode]
 when :list
@@ -74,13 +81,25 @@ when :all
   puts 'Triggering agent runs:'
   containers.each do |identity|
     puts "############# #{identity} ###############"
-    system('docker', 'exec', identity, 'puppet', 'agent', '-t', *ARGV)
+    if options.include? :interval
+      # Detach from process so we don't have to wait for it to complete
+      system('docker', 'exec', '-d', identity, 'puppet', 'agent', '-t', *ARGV)
+      sleep options[:interval]
+    else
+      system('docker', 'exec', identity, 'puppet', 'agent', '-t', *ARGV)
+    end
   end
 
 when :reset
   if options.include? :identity
+    print "Resetting the SSL certificate for #{options[:identity]}. Continue? [Y/n]: "
+    exit 1 if [ 'n', 'no'].include? STDIN.gets.strip.downcase
+
     reset(options[:identity])
   else
+    print "Resetting the SSL certificates for ALL CONTAINERS. Continue? [y/N]: "
+    exit 1 unless [ 'y', 'yes'].include? STDIN.gets.strip.downcase
+
     containers.each do |identity|
       reset(identity)
     end


### PR DESCRIPTION
This will allow users to run agents concurrently, which will be useful
for the "stress testing" we do in the capstone. It also adds a couple
sanity checks to make sure certs don't get wiped accidentally.