### PR TITLE
Mitigate file ownership issue

### DIFF
--- a/manifests/master/student_environment.pp
+++ b/manifests/master/student_environment.pp
@@ -54,6 +54,23 @@ class classroom::master::student_environment {
     value   => $environmentpath,
   }
 
+  # mitigate PE-11356
+  if $::pe_server_version == '2015.2.0' {
+    pe_ini_setting { 'puppetserver puppetconf user':
+      setting => 'user',
+      path    => '/etc/puppetlabs/puppet/puppet.conf',
+      value   => 'pe-puppet',
+      section => 'main'
+    }
+
+    pe_ini_setting { 'puppetserver puppetconf group':
+      setting => 'group',
+      path    => '/etc/puppetlabs/puppet/puppet.conf',
+      value   => 'pe-puppet',
+      section => 'main'
+    }
+  }
+
   # mitigate PE-11366
   dirtree { '/opt/puppetlabs/server':
     path   => '/opt/puppetlabs/server',


### PR DESCRIPTION
Prior to this, the ownership of several files would flip/flop on every
single puppet run ever. Minorly annoying. Actually, majorly annoying,
because if you ran a `puppet apply` command, then the ownerships would
flip, but not flop, and then subsequent CSRs made by agents to that
compile master would fail with an HTTP 500. (sadpanda)

https://tickets.puppetlabs.com/browse/PE-11356