### PR TITLE
Ensure that hiera.yaml only gets written once

### DIFF
--- a/manifests/agent/hiera.pp
+++ b/manifests/agent/hiera.pp
@@ -50,10 +50,12 @@ class classroom::agent::hiera {
       ensure => directory,
     }
 
-    # Because PE writes a default, we cannot use replace => false
-    file { "${classroom::codedir}/hiera.yaml":
-      ensure => file,
-      content => template('classroom/hiera/hiera.agent.yaml.erb'),
+    # Because PE writes a default, we have to do tricks to see if we've already managed this.
+    unless defined('$puppetlabs_class') {
+      file { "${classroom::codedir}/hiera.yaml":
+        ensure  => file,
+        content => template('classroom/hiera/hiera.agent.yaml.erb'),
+      }
     }
   }
 

--- a/manifests/course/architect.pp
+++ b/manifests/course/architect.pp
@@ -50,4 +50,8 @@ class classroom::course::architect (
     # Set up agent containers on student masters
     include classroom::containers
   }
+
+  class { 'classroom::facts':
+    coursename => 'architect',
+  }
 }

--- a/manifests/course/fundamentals.pp
+++ b/manifests/course/fundamentals.pp
@@ -15,4 +15,8 @@ class classroom::course::fundamentals (
     role      => $role,
     manageyum => $manageyum,
   }
+
+  class { 'classroom::facts':
+    coursename => 'fundamentals',
+  }
 }

--- a/manifests/course/practitioner.pp
+++ b/manifests/course/practitioner.pp
@@ -24,4 +24,8 @@ class classroom::course::practitioner (
   }
   # Everyone gets Irssi
   include classroom::agent::irc
+
+  class { 'classroom::facts':
+    coursename => 'practitioner',
+  }
 }

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -1,0 +1,26 @@
+# This class writes out some moderately interesting external facts. These are
+# useful for demonstrating structured facts.
+#
+# Their existence also serves as a marker that initial provisioning has taken
+# place, for the small handful of items that we only want to manage once.
+#
+class classroom::facts (
+  $coursename,
+  $role = $classroom::params::role,
+) inherits classroom::params {
+
+  File {
+    owner => 'root',
+    group => 'root',
+    mode  => '0644',
+  }
+
+  file { [ '/etc/puppetlabs/facter/', '/etc/puppetlabs/facter/facts.d/' ]:
+    ensure => directory,
+  }
+
+  file { '/etc/puppetlabs/facter/facts.d/puppetlabs.txt':
+    ensure  => file,
+    content => template('classroom/facts.txt.erb'),
+  }
+}

--- a/templates/facts.txt.erb
+++ b/templates/facts.txt.erb
@@ -1,0 +1,2 @@
+puppetlabs_class=<%= @coursename %>
+puppetlabs_role=<%= @role %>


### PR DESCRIPTION
Make sure that we can edit hiera.yaml in Architect. This may be useful
for other things too, since their existance can be used as flags that
the initial classroom provisioning has taken place, and the facts can be
used to quickly demo external structured facts.

TRAINTECH-232 #resolved