### PR TITLE
Update the path for 2015.2

### DIFF
--- a/files/process_reports.rb
+++ b/files/process_reports.rb
@@ -14,7 +14,7 @@ Puppet.initialize_settings
 
 username  = `who -m`.split.first
 datafile  = File.expand_path("~#{username}/puppetruns.yaml")
-reportdir = Puppet.settings[:reportdir]
+reportdir = '/opt/puppetlabs/server/data/puppetserver/reports/' #Puppet.settings[:reportdir]
 stats     = {}
 
 # If this were to be used in production, you would want to increment counts in


### PR DESCRIPTION
This is **not** backwards compatible, but I don't know a real clean way
to make it so without completely reworking this. There's not a simple
way of getting the master's reportdir anymore.