### PR TITLE
Fixing error on windows clients (unable to create puppetlabs.txt in facts.d)

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -9,18 +9,27 @@ class classroom::facts (
   $role = $classroom::params::role,
 ) inherits classroom::params {
 
-  File {
-    owner => 'root',
-    group => 'root',
-    mode  => '0644',
+  if $::osfamily == 'windows' {
+    file {'C:\ProgramData\PuppetLabs\facter\fact.d':
+      ensure => directory,
+    }
+    file { 'C:\ProgramData\PuppetLabs\facter\fact.d\puppetlabs.txt':
+      ensure  => file,
+      content => template('classroom/facts.txt.erb'),
+    }
   }
-
-  file { [ '/etc/puppetlabs/facter/', '/etc/puppetlabs/facter/facts.d/' ]:
-    ensure => directory,
-  }
-
-  file { '/etc/puppetlabs/facter/facts.d/puppetlabs.txt':
-    ensure  => file,
-    content => template('classroom/facts.txt.erb'),
+  else {
+    File {
+      owner => 'root',
+      group => 'root',
+      mode  => '0644',
+    }
+    file { [ '/etc/puppetlabs/facter/', '/etc/puppetlabs/facter/facts.d/' ]:
+      ensure => directory,
+    }
+    file { '/etc/puppetlabs/facter/facts.d/puppetlabs.txt':
+      ensure  => file,
+      content => template('classroom/facts.txt.erb'),
+    }
   }
 }


### PR DESCRIPTION
Windows clients run in to trouble with the linux paths for the puppetlabs.txt. This if/else flow adds the windows support, so that the puppetlabs.txt will also be created in the propper directory on windows nodes. This has been tested on Windows 2008r2.