### PR TITLE
Fix docker

### DIFF
--- a/manifests/master/docker_registry.pp
+++ b/manifests/master/docker_registry.pp
@@ -3,24 +3,30 @@ class classroom::master::docker_registry {
     extra_parameters => '--insecure-registry localhost:5000',
   }
 
-  docker::image { 'registry:2': }
+  docker::image { 'registry':
+    image_tag => '2',
+  }
+
   docker::run {'registry':
     image            => 'registry:2',
     ports            => ['5000:5000'],
   }
 
   # Cache the centos image in the local registry
-  $image_name = "centos:${::operatingsystemmajrelease}"
-  docker::image { $image_name: }
+  docker::image { 'centos':
+    image_tag => $::operatingsystemmajrelease,
+  }
 
   # Tag image
+  $image_name = "centos:${::operatingsystemmajrelease}"
   exec { "docker tag ${image_name} localhost:5000/${image_name}":
     path    => '/usr/bin/:/bin',
     unless  => "docker images | grep localhost:5000/centos",
-    require => Docker::Image[$image_name],
+    require => Docker::Image['centos'],
   }
   exec { "docker push localhost:5000/${image_name}":
-    path    => '/usr/bin/',
+    path    => $::path,
+    unless  => "curl -Is -X GET http://localhost:5000/v2/centos/manifests/${::operatingsystemmajrelease} | grep '200 OK'",
     require => Exec["docker tag ${image_name} localhost:5000/${image_name}"]
   }
 }

--- a/manifests/master/docker_registry.pp
+++ b/manifests/master/docker_registry.pp
@@ -1,5 +1,7 @@
 class classroom::master::docker_registry {
-  include docker
+  class {'docker':
+    extra_parameters => '--insecure-registry localhost:5000',
+  }
 
   docker::image { 'registry:2': }
   docker::run {'registry':


### PR DESCRIPTION
There was an issue where the master could not push the centos:6 image to it's own registry due so SSL verification issues (It need verification to be turned off as it was not using legit certs). For some reason this has not shown its head until now. I really cannot work out why... 

If someone wants to try to confirm my issue before we merge this would be great so that we can be sure we are fixing the right thing:
  1. Spin Up a master
  2. Install PE
  3. `puppet module install pltraining/classroom`
  4. Set up site.pp:
```
echo "node default {
  # This is where you can declare classes for all nodes.
  # Example:
  #   class { 'my_class': }
  include classroom::course::architect
}" > /etc/puppetlabs/code/environments/production/manifests/site.pp
```

  5. `puppet agent -t` **Do this a couple of time to be sure**

The error should look lie this:
```
Notice: /Stage[main]/Classroom::Master::Docker_registry/Exec[docker push localhost:5000/centos:6]/returns:  v1 ping attempt failed with error: Get https://localhost:5000/v1/_ping: tls: oversized record received with length 20527. If this private registry supports only HTTP or HTTPS with an unknown CA certificate, please add `--insecure-registry localhost:5000` to the daemon's arguments. In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag; simply place the CA certificate at /etc/docker/certs.d/localhost:5000/ca.crt
Error: docker push localhost:5000/centos:6 returned 1 instead of one of [0]
Error: /Stage[main]/Classroom::Master::Docker_registry/Exec[docker push localhost:5000/centos:6]/returns: change from notrun to
```