### PR TITLE
Switch from exec of curl to pget for Win 2k8 compatibility

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -19,13 +19,13 @@ class classroom::windows {
     require  => Class['chocolatey'],
   }
  
-  # Unzip package is broken on chocolatey so download directly
-  exec { 'curl http://iweb.dl.sourceforge.net/project/gnuwin32/unzip/5.51-1/unzip-5.51-1.exe -Outfile C:/Windows/Temp/unzip.exe':
-    provider => powershell,
-    creates  => 'C:/Windows/Temp/unzip.exe',
-    before   => Package['GnuWin32: UnZip version 5.51'],
+  # The Chocolatey Unzip package is broken; use pget and a package resource.
+  pget { 'unzip':
+    source         => 'http://iweb.dl.sourceforge.net/project/gnuwin32/unzip/5.51-1/unzip-5.51-1.exe',
+    target         => 'C:/Windows/Temp',
+    targetfilename => 'unzip.exe',
+    before         => Package['GnuWin32: UnZip version 5.51'],
   }
-
   package { 'GnuWin32: UnZip version 5.51':
     ensure          => present,
     provider        => 'windows',

--- a/metadata.json
+++ b/metadata.json
@@ -26,6 +26,7 @@
   "description": "Important! This is not the module you are looking for\n    unless you are a trainer teaching Puppet Labs training courses!\n    - Configures and sets up classroom environment for Puppet Classroom trainings.",
   "dependencies": [
     {"name":"chocolatey/chocolatey",          "version_requirement":">= 1.2.0"},
+    {"name":"cyberious/pget",                 "version_requirement":">= 1.1.0"},
     {"name":"dwerder/graphite",               "version_requirement":">= 5.14.0"},
     {"name":"dwerder/grafana",                "version_requirement":">= 1.2.0"},
     {"name":"garethr/docker",                 "version_requirement":">= 4.0.2"},


### PR DESCRIPTION
This commit restores Windows 2008 compatibility.  It switches from using an exec of `curl` to using an actual type and provider available in the cyberious/pget forge module that works in both 2k8 and 2k12.