### PR TITLE
Restore management of modulepath symlink

### DIFF
--- a/manifests/agent/workdir.pp
+++ b/manifests/agent/workdir.pp
@@ -43,6 +43,21 @@ define classroom::agent::workdir (
       ensure => directory,
     }
 
+    file { "${classroom::codedir}/modules":
+      ensure => link,
+      target => "${workdir}/modules",
+      force  => true,
+    }
+
+    # Symlinks on the user desktop
+    if $::osfamily == 'Windows' {
+      $linkname = basename($workdir)
+      file { "C:/Users/Administrator/Desktop/${linkname}":
+        ensure => link,
+        target => $workdir,
+      }
+    }
+
     if $populate {
       # create the modules, manifests, site.pp and environment.conf
       # environment.conf required to prevent caching
@@ -98,15 +113,6 @@ define classroom::agent::workdir (
       ensure  => file,
       source  => 'puppet:///modules/classroom/dot_gitignore',
       require => Exec["initialize ${name} repo"],
-    }
-
-    # Symlinks on the user desktop
-    if $::osfamily == 'Windows' {
-      $linkname = basename($workdir)
-      file { "C:/Users/Administrator/Desktop/${linkname}":
-        ensure => link,
-        target => $workdir,
-      }
     }
 
   }


### PR DESCRIPTION
In a demonstration of the dangers of hidden coupling, the removal of the
teams functionality that nobody uses accidentally removed the management
of the modulepath symlink. That *had* been in the team management, so
that it could link to either the student's own workdir or the team
workdir, depending on progress. It is now directly in the `workdir` type.

TODO: there is no longer any reason for `workdir` to be a type. That was
to allow a workdir for the student and for the team.

TRAINTECH-335 #resolved #time 45m