### PR TITLE
TRAINTECH-328

### DIFF
--- a/files/windows/setup_classroom.ps1
+++ b/files/windows/setup_classroom.ps1
@@ -1,0 +1,6 @@
+#######################
+### determine agent ###
+#######################
+$dir = C:\Users\Administrator\Downloads
+$agent = Get-ChildItem $dir | Where-Object {$_.Extension -eq ".msi"}
+msiexec /qn /norestart /l*v puppet_agent_install.log /i $agent.fullname PUPPET_MASTER_SERVER=master.puppetlabs.vm

--- a/files/windows/setup_classroom.ps1
+++ b/files/windows/setup_classroom.ps1
@@ -1,6 +1,6 @@
 #######################
 ### determine agent ###
 #######################
-$dir = C:\Users\Administrator\Downloads
+$dir = "C:\Users\Administrator\Downloads"
 $agent = Get-ChildItem $dir | Where-Object {$_.Extension -eq ".msi"}
 msiexec /qn /norestart /l*v puppet_agent_install.log /i $agent.fullname PUPPET_MASTER_SERVER=master.puppetlabs.vm

--- a/files/windows/setup_windows.ps1
+++ b/files/windows/setup_windows.ps1
@@ -12,7 +12,7 @@ If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 ### Set the computer name ###
 #############################
 $computerName = Read-Host -Prompt 'Input desired user name: '
-Rename-Computer $ComputerName
+Rename-Computer $ComputerName.ToLower()
 
 #########################
 ### Set the FQDN name ###

--- a/files/windows/setup_windows.ps1
+++ b/files/windows/setup_windows.ps1
@@ -1,11 +1,13 @@
 ##############################
 ### Check if Administrator ###
 ##############################
-If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(`
-    [Security.Principal.WindowsBuiltInRole] "Administrator"))
-{
-    Write-Warning "You do not have Administrator rights to run this script!`nPlease re-run this script as an Administrator!"
-    Break
+$user = [Environment]::UserName
+If ($user -ne "Administrator") {
+      Write-Host "`n`n`nPlease logout and login as Administrator!`n`n`n"
+      Start-Sleep -s 5
+      break
+} else {
+      Write-Host "`n`n`nContinuing the setup.`n`n`n"
 }
 
 #############################
@@ -45,20 +47,25 @@ rm -force c:\secpol.cfg -confirm:$false
 ### Download setup_classroom.ps1 ###
 ####################################
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}
-$url = "https://$master_ip:8140/packages/current/windows-x86_64/setup_classroom.ps1"
+$url = "https://master.puppetlabs.vm:8140/packages/current/windows-x86_64/setup_classroom.ps1"
 $output = "C:\Users\Administrator\setup_classroom.ps1"
 (New-Object System.Net.WebClient).DownloadFile($url, $output)
 
 #############################
 ### Download puppet agent ###
 #############################
-$url = "https://$master_ip:8140/packages/current/windows-x86_64/puppet-agent-x64.msi"
+$url = "https://master.puppetlabs.vm:8140/packages/current/windows-x86_64/puppet-agent-x64.msi"
 $output = "C:\Users\Administrator\Downloads\puppet-agent-x64.msi"
 (New-Object System.Net.WebClient).DownloadFile($url, $output)
 
 ############################
 ### Restart the computer ###
 ############################
-Start-Sleep -s 5
-Write-Host "`n`n`nRebooting in 5 seconds`n`n`n"
-Restart-Computer
+$confirmation = Read-Host "`n`n`nRebooting in 5 seconds, continue? y/n`n`n`n"
+If ($confirmation -eq 'y') {
+    Start-Sleep -s 5
+    Restart-Computer
+} else {
+    Write-Host "`n`n`nYou will have to reboot manually to continue with the setup!`n`n`n"
+    break
+}

--- a/files/windows/setup_windows.ps1
+++ b/files/windows/setup_windows.ps1
@@ -1,0 +1,64 @@
+##############################
+### Check if Administrator ###
+##############################
+If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(`
+    [Security.Principal.WindowsBuiltInRole] "Administrator"))
+{
+    Write-Warning "You do not have Administrator rights to run this script!`nPlease re-run this script as an Administrator!"
+    Break
+}
+
+#############################
+### Set the computer name ###
+#############################
+$computerName = Read-Host -Prompt 'Input desired user name: '
+Rename-Computer $ComputerName
+
+#########################
+### Set the FQDN name ###
+#########################
+$DNSSuffix = "puppetlabs.vm"
+$oldDNSSuffix = (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\" -Name "NV Domain")."NV Domain"
+
+Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\" -Name Domain -Value $DNSSuffix
+Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\" -Name "NV Domain" -Value $DNSSuffix
+
+#################################
+### Set host entry for master ###
+#################################
+Start-Sleep -s 3
+$master_ip = Read-Host -Prompt 'Input the IP Address of the Master'
+Write-Host "`n`nAdding entry to the hosts file`n`n"
+ac -Encoding UTF8 C:\Windows\system32\drivers\etc\hosts "$master_ip master.$DNSSuffix master"
+
+###########################################
+### Set password complexity requirement ###
+###########################################
+Start-Sleep -s 3
+Write-Host "`n`nSetting Local Security Settings`n`n"
+secedit /export /cfg c:\secpol.cfg
+(gc C:\secpol.cfg).replace("PasswordComplexity = 1", "PasswordComplexity = 0") | Out-File C:\secpol.cfg
+secedit /configure /db c:\windows\security\local.sdb /cfg c:\secpol.cfg /areas SECURITYPOLICY
+rm -force c:\secpol.cfg -confirm:$false
+
+####################################
+### Download setup_classroom.ps1 ###
+####################################
+[System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}
+$url = "https://$master_ip:8140/packages/current/windows-x86_64/setup_classroom.ps1"
+$output = "C:\Users\Administrator\setup_classroom.ps1"
+(New-Object System.Net.WebClient).DownloadFile($url, $output)
+
+#############################
+### Download puppet agent ###
+#############################
+$url = "https://$master_ip:8140/packages/current/windows-x86_64/puppet-agent-x64.msi"
+$output = "C:\Users\Administrator\Downloads\puppet-agent-x64.msi"
+(New-Object System.Net.WebClient).DownloadFile($url, $output)
+
+############################
+### Restart the computer ###
+############################
+Start-Sleep -s 5
+Write-Host "`n`n`nRebooting in 5 seconds`n`n`n"
+Restart-Computer

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -66,6 +66,9 @@ class classroom::master {
   # configure Hiera environments for the master
   include classroom::master::hiera
 
+  # Setup Windows Powershell Scripts
+  include classroom::master::windows
+
   # Now create all of the users who've checked in
   Classroom::User <<||>>
 

--- a/manifests/master/agent_tarball.pp
+++ b/manifests/master/agent_tarball.pp
@@ -9,7 +9,7 @@ class classroom::master::agent_tarball {
   # https://pm.puppetlabs.com/puppet-agent/2015.2.0/1.2.2/repos/puppet-agent-el-6-x86_64.tar.gz
   $filename    = "puppet-agent-${::platform_tag}.tar.gz"
   $download    = "https://pm.puppetlabs.com/puppet-agent/${pe_server_version}/${aio_agent_version}/repos/${filename}"
-  $destination = "${publicdir}/${pe_server_version}/${aio_agent_version}/repos"
+  $destination = "${publicdir}/classroom/${pe_server_version}/${aio_agent_version}/repos"
 
   dirtree { $destination:
     path    => $destination,

--- a/manifests/master/windows.pp
+++ b/manifests/master/windows.pp
@@ -1,0 +1,24 @@
+# Make sure the windows setup files are on the master for the students
+# to download and configure the Windows Server for the installation of
+# the puppet agent.
+class classroom::master::windows {
+  assert_private('This class should not be called directly')
+
+  File {
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+
+  $publicdir   = "/opt/puppetlabs/server/data/packages/public"
+  $destination = "${publicdir}/${pe_server_version}/windows-x86_64"
+
+  file { "${destination}/setup_windows.ps1":
+    source => "puppet:///modules/classroom/windows/setup_windows.ps1",
+  }
+
+  file { "${destination}/setup_classroom.ps1":
+    source => "puppet:///modules/classroom/windows/setup_classroom.ps1",
+  }
+}

--- a/manifests/master/windows.pp
+++ b/manifests/master/windows.pp
@@ -4,6 +4,8 @@
 class classroom::master::windows {
   assert_private('This class should not be called directly')
 
+  $publicdir = $classroom::params::publicdir
+
   File {
     ensure => file,
     owner  => 'root',
@@ -11,7 +13,6 @@ class classroom::master::windows {
     mode   => '0644',
   }
 
-  $publicdir   = "/opt/puppetlabs/server/data/packages/public"
   $destination = "${publicdir}/${pe_server_version}/windows-x86_64"
 
   file { "${destination}/setup_windows.ps1":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,8 +38,8 @@ class classroom::params {
   # time servers to use if we've got network
   $time_servers = ['0.pool.ntp.org iburst', '1.pool.ntp.org iburst', '2.pool.ntp.org iburst', '3.pool.ntp.org']
 
-  # where the agent installer tarball for secondary masters should go.
-  $publicdir = '/opt/puppetlabs/server/data/packages/public/classroom'
+  # for where the agent installer tarball and windows powershell scripts go.
+  $publicdir = '/opt/puppetlabs/server/data/packages/public'
 
   # The directory where the VM caches stuff locally
   $cachedir = '/usr/src/installer'


### PR DESCRIPTION
Powershell scripts to configure the Windows Server for the installation of the puppet-agent per request of partner trainers.

To use: 
 - Open Powershell
 - execute "[System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}"
 - execute "(New-Object System.Net.WebClient).DownloadFile("https://<ip address of master>:8140/packages/current/windows-x86_64/setup_windows.ps1", "C:\Users\Administrator\setup_windows.ps1")

 -execute "setup_windows.ps1"

The system will reboot, when the system returns
 - Open Powershell
 - execute setup_classroom.ps1


-- Files --
setup_windows.ps1 configures the server for install of puppet-agent
setup_classroom.ps1 installs and configures puppet-agent
