### PR TITLE
Use a generic name

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -12,7 +12,7 @@ class classroom::proxy {
     },
   }
 
-  haproxy::listen { 'wordpress00':
+  haproxy::listen { 'web00':
     ipaddress => $::ipaddress,
     ports     => '80',
     options   => {


### PR DESCRIPTION
We're not specifically a wordpress pool, since this might be wordpress
or drupal.

COURSES-1550 #resolved 30m