### PR TITLE
Don't block concat anymore

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     {"name":"pltraining/rbac",                "version_requirement":">= 0.0.2"},
     {"name":"pltraining/userprefs",           "version_requirement":">= 0.0.3"},
     {"name":"puppetlabs/apache",              "version_requirement":">= 1.1.1"},
-    {"name":"puppetlabs/concat",              "version_requirement":"< 2.0.0"},
+    {"name":"puppetlabs/concat",              "version_requirement":">= 1.1.1"},
     {"name":"puppetlabs/git",                 "version_requirement":">= 0.2.0"},
     {"name":"puppetlabs/haproxy",             "version_requirement":">= 1.0.0"},
     {"name":"puppetlabs/inifile",             "version_requirement":">= 1.0.0"},


### PR DESCRIPTION
This was to work around an upstream bug. `puppetlabs/apache` now pins
its dependency properly, so we can just let that resolve on its own.

https://github.com/puppetlabs/puppetlabs-apache/blob/master/metadata.json#L12

TRAINTECH-101 #resolved #time 1h