### PR TITLE
On windows agents, suppress git line-endings warnings

### DIFF
--- a/files/dot_gitattributes_windows
+++ b/files/dot_gitattributes_windows
@@ -1,0 +1,46 @@
+# These settings are for using Puppet with git on windows
+
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
+# the puppetlabs/dsc module has these
+*.psd1 text eol=lf
+*.psm1 text eol=lf
+
+# This is for the README, Rakefile etc. Have to revisit in case of issues
+# with files that are not identified as binaries
+* text eol=lf
+
+
+#
+## These files are binary and should be left untouched
+#
+
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary
+*.exe binary

--- a/manifests/agent/workdir.pp
+++ b/manifests/agent/workdir.pp
@@ -107,6 +107,11 @@ define classroom::agent::workdir (
         mode    => '0755',
         require => Exec["initialize ${name} repo"],
       }
+      file { "${workdir}/.gitattributes":
+        ensure  => file,
+        source  => 'puppet:///modules/classroom/dot_gitattributes_windows',
+        require => Exec["initialize ${name} repo"],
+      }
     }
 
     file { "${workdir}/.gitignore":


### PR DESCRIPTION
Previously, on windows agents, with git, you would get messages like:

PS C:\puppetcode> git add .\modules\dsc
warning: LF will be replaced by CRLF in modules/dsc/Gemfile.
The file will have its original line endings in your working directory.
warning: LF will be replaced by CRLF in modules/dsc/LICENSE.
The file will have its original line endings in your working directory.

When adding a few new modules, the warning messages are overwhelming
since there's one for each new file with unix LF line-endings.

This commit adds a managed .gitattributes file that will suppress these
warnings.