### PR TITLE
Use the current symlink

### DIFF
--- a/manifests/master/windows.pp
+++ b/manifests/master/windows.pp
@@ -13,7 +13,7 @@ class classroom::master::windows {
     mode   => '0644',
   }
 
-  $destination = "${publicdir}/${pe_server_version}/windows-x86_64"
+  $destination = "${publicdir}/current/windows-x86_64"
   
   file { $destination:
     ensure => directory,


### PR DESCRIPTION
This way it won't break on pre-releases

TRAINTECH-470 #resolved #time 15m