### PR TITLE
Don't break the pe_repo class

### DIFF
--- a/manifests/master/windows.pp
+++ b/manifests/master/windows.pp
@@ -2,6 +2,7 @@
 # to download and configure the Windows Server for the installation of
 # the puppet agent.
 class classroom::master::windows {
+  require pe_repo::platform::windows_x86_64
   assert_private('This class should not be called directly')
 
   $publicdir = $classroom::params::publicdir
@@ -14,10 +15,6 @@ class classroom::master::windows {
   }
 
   $destination = "${publicdir}/current/windows-x86_64"
-  
-  file { $destination:
-    ensure => directory,
-  }
 
   file { "${destination}/setup_windows.ps1":
     source => "puppet:///modules/classroom/windows/setup_windows.ps1",


### PR DESCRIPTION
Making this directory caused the symlink dropped in place by `pe_repo`
to break. But we don't need to create it, because `pe_repo` already did.
Instead, let's just make sure that class is enforced first.

TRAINTECH-478 #resolved #time 30m