### PR TITLE
Simplified windows agent install

### DIFF
--- a/manifests/master/windows.pp
+++ b/manifests/master/windows.pp
@@ -14,13 +14,13 @@ class classroom::master::windows {
     mode   => '0644',
   }
 
-  $destination = "${publicdir}/current/windows-x86_64"
+  $destination = "${publicdir}/current"
 
   file { "${destination}/setup_windows.ps1":
     source => "puppet:///modules/classroom/windows/setup_windows.ps1",
   }
 
-  file { "${destination}/setup_classroom.ps1":
+  file { "${destination}/windows-x86_64/setup_classroom.ps1":
     source => "puppet:///modules/classroom/windows/setup_classroom.ps1",
   }
 }

--- a/manifests/master/windows.pp
+++ b/manifests/master/windows.pp
@@ -1,6 +1,11 @@
 # Make sure the windows setup files are on the master for the students
 # to download and configure the Windows Server for the installation of
 # the puppet agent.
+
+# Works similarly to curl | bash solution for linux with the following commands in powershell
+# [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}
+# iex (New-Object System.Net.WebClient).DownloadString('https://ipaddress:8140/packages/current/setup_windows.ps1')
+
 class classroom::master::windows {
   require pe_repo::platform::windows_x86_64
   assert_private('This class should not be called directly')


### PR DESCRIPTION
Lets windows install work like curl | bash linux install.
This moves the setup_windows.ps1 to the same directory as install.bash