### PR TITLE
Enable environment caching

### DIFF
--- a/files/hiera/data/classroom.yaml
+++ b/files/hiera/data/classroom.yaml
@@ -2,3 +2,4 @@
 puppet_enterprise::profile::console::rbac_session_timeout: 4320
 puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'
 pe_repo::base_path: 'https://master.puppetlabs.vm:8140/packages/classroom'
+puppet_enterprise::master::puppetserver::jruby_environment_class_cache_enabled: true

--- a/files/hiera/data/classroom.yaml
+++ b/files/hiera/data/classroom.yaml
@@ -3,3 +3,4 @@ puppet_enterprise::profile::console::rbac_session_timeout: 4320
 puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'
 pe_repo::base_path: 'https://master.puppetlabs.vm:8140/packages/classroom'
 puppet_enterprise::master::puppetserver::jruby_environment_class_cache_enabled: true
+puppet_enterprise::profile::console::classifier_synchronization_period: 300


### PR DESCRIPTION
This **requires** #150 to be merged before release!

This will enable environment caching, which might give us some performance improvements.

https://docs.puppet.com/pe/latest/release_notes.html#environment-class-cache-enabled-server-setting

See https://tickets.puppetlabs.com/browse/PE-15282 for conversation