### PR TITLE
Only apply the peadmin class to agents

### DIFF
--- a/manifests/course/virtual/code_management.pp
+++ b/manifests/course/virtual/code_management.pp
@@ -4,7 +4,6 @@ class classroom::course::virtual::code_management (
 ) inherits classroom::params {
  
   include r10k::mcollective
-  include puppet_enterprise::profile::mcollective::peadmin
   
   if $role == 'master' {
     class { 'puppetfactory':
@@ -22,5 +21,6 @@ class classroom::course::virtual::code_management (
     }
   } else {
     include r10k
+    include puppet_enterprise::profile::mcollective::peadmin
   }
 }


### PR DESCRIPTION
This was breaking because of something with the PE master.  Since the profile is already included on the master, just apply it to the agent.