### PR TITLE
Fix peadmin profile

### DIFF
--- a/manifests/course/virtual/code_management.pp
+++ b/manifests/course/virtual/code_management.pp
@@ -2,10 +2,9 @@ class classroom::course::virtual::code_management (
   $session_id = $classroom::params::session_id,
   $role = $classroom::params::role,
 ) inherits classroom::params {
- 
+
   include r10k::mcollective
-  include puppet_enterprise::profile::mcollective::peadmin
-  
+
   if $role == 'master' {
     class { 'puppetfactory':
       # Put students' puppetcode directories somewhere less distracting
@@ -22,5 +21,14 @@ class classroom::course::virtual::code_management (
     }
   } else {
     include r10k
+    puppet_enterprise::mcollective::client { 'peadmin':
+      activemq_brokers => ['master.puppetlabs.vm'],
+      keypair_name     => 'pe-internal-peadmin-mcollective-client',
+      create_user      => true,
+      logfile          => '/var/lib/peadmin/.mcollective.d/client.log',
+      stomp_password   => pe_chomp(file('/etc/puppetlabs/mcollective/credentials','/dev/null')),
+      stomp_port       => 61613,
+      stomp_user       => 'mcollective',
+    }
   }
 }


### PR DESCRIPTION
Changes in the puppet_enterprise module broke this for us.  This declares the peadmin mco client user more directly without depending on params inherited from puppet_enterprise or puppet_enterprise::params classes.