### PR TITLE
Add performance logging and reporting

### DIFF
--- a/files/classroom_performance
+++ b/files/classroom_performance
@@ -1,0 +1,105 @@
+#! /usr/bin/env ruby
+require 'json'
+require 'logger'
+require 'fileutils'
+
+TTL          = (2.5 * 60 * 60 * 24).to_i  # 2.5 days
+LOGGER       = Logger.new('/var/log/puppetlabs/classroom')
+LOGGER.level = Logger::DEBUG
+
+## AWS configuration
+AWS_REGION = 's3-us-west-2.amazonaws.com'
+AWS_ACCESS = 'AKIAJZPNPIYQDXOJTFKA'
+AWS_SECRET = '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'
+AWS_BUCKET = 'classroom-performance'
+
+def display_help
+  puts "This will take regular performance related snapshots and then upload"
+  puts "to our S3 bucket for engineering analysis near the end of your delivery."
+  puts
+  puts "You may also use it to record performance notes into the classroom log."
+  puts
+  puts "Usage: classroom_performance [ log <message> | report | snapshot ]"
+  puts
+  puts "Interactive commands:"
+  puts "  * log: Record a message into classroom log. This should be the only command you use."
+  puts
+  puts "System commands (run via cron):"
+  puts "  * report: Upload classroom log for analysis."
+  puts "  * snapshot: Take a periodic snapshot of classroom statistics."
+  puts
+end
+
+# if the classroom infrastructure is older than TTL
+def time_to_report
+  files = Dir.glob('/etc/puppetlabs/puppet/ssl/certs/*').reject do |cert|
+    File.basename(cert) =~ /^(master\.|pe-internal-|ca\.)/
+  end
+  files.map! { |file| File.new(file).ctime }
+  files.sort!
+
+  # rough median, should indicate the age of the classroom infrastructure
+  Time.now > (files[files.length / 2] + TTL)
+end
+
+def submit_logs
+  require 'aws/s3'
+
+  event_id = JSON.parse(File.read('/home/training/courseware/showoff.json'))['key'] rescue nil || Time.now.to_i
+  filename = "classroom-perflogs-#{event_id}.tar.gz"
+  system("tar -cf /var/cache/#{filename} /var/log/puppetlabs/")
+
+  begin
+    AWS::S3::DEFAULT_HOST.replace AWS_REGION
+    AWS::S3::Base.establish_connection!(
+      :access_key_id     => AWS_ACCESS,
+      :secret_access_key => AWS_SECRET
+    )
+    AWS::S3::S3Object.store(filename, open("/var/cache/#{filename}"), AWS_BUCKET)
+  rescue => e
+    LOGGER.warn "S3 upload failed. No network?"
+    LOGGER.warn e.message
+    LOGGER.debug e.backtrace
+
+    # Only a successful upload should stay
+    FileUtils.rm filename
+  end
+
+end
+
+def already_reported
+  # if a file exists matching this pattern, then we've already submitted
+  not Dir.glob('/var/cache/classroom-perflogs*').empty?
+end
+
+def record_snapshot
+  LOGGER.debug "-------------------------------- top -bn1 ----------------------------------\n#{`top -bn1`}"
+  LOGGER.debug "-------------------------------- vmstat ------------------------------------\n#{`vmstat`}"
+  LOGGER.debug "-------------------------------- netstat -a --------------------------------\n#{`netstat -a`}"
+  LOGGER.debug "-------------------------------- iostat ------------------------------------\n#{`iostat`}"
+  LOGGER.debug "-------------------------------- mpstat -P ALL -----------------------------\n#{`mpstat -P ALL`}"
+
+  FileUtils.mkdir_p '/var/log/puppetlabs/classroom-traffic'
+  `tcpdump -G 30 -W 1 -w /var/log/puppetlabs/classroom-traffic/#{Time.now.to_i}.pcap -i any > /dev/null 2>&1 &`
+end
+
+
+#### program starts ####
+case ARGV.shift
+when 'report'
+  exit 0 if already_reported
+  exit 0 unless time_to_report
+  submit_logs
+
+when 'log'
+  message = ARGV.empty? ? "Misc performance issue noted." : ARGV.join(' ')
+  LOGGER.warn message
+  record_snapshot
+
+when 'snapshot'
+  LOGGER.debug "Scheduled performance snapshot"
+  record_snapshot
+
+else
+  display_help
+end

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -76,4 +76,7 @@ class classroom::master {
   # Add files required for labs (mostly for offline mode)
   include classroom::master::lab_files
 
+  # Configure performance logging
+  include classroom::master::perf_logging
+
 }

--- a/manifests/master/perf_logging.pp
+++ b/manifests/master/perf_logging.pp
@@ -1,0 +1,26 @@
+# Performance logging for the classroom.
+class classroom::master::perf_logging {
+  assert_private('This class should not be called directly')
+
+  file { '/usr/local/bin/classroom_performance':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/classroom/classroom_performance',
+  }
+
+  cron { 'snapshot performance':
+    ensure  => present,
+    command => '/usr/local/bin/classroom_performance snapshot',
+    minute  => ['12', '42'],
+  }
+
+  # upload report if more than 2.5 days have passed.
+  cron { 'submit performance report':
+    ensure  => present,
+    command => '/usr/local/bin/classroom_performance report',
+    minute  => ['47'],
+  }
+
+}

--- a/manifests/master/perf_logging.pp
+++ b/manifests/master/perf_logging.pp
@@ -2,6 +2,10 @@
 class classroom::master::perf_logging {
   assert_private('This class should not be called directly')
 
+  package { ['sysstat', 'tcpdump']:
+    ensure => present,
+  }
+
   file { '/usr/local/bin/classroom_performance':
     ensure => file,
     owner  => 'root',


### PR DESCRIPTION
This will take performance snapshots every 30 minutes, and then upload
them to an S3 bucket once the classroom infrastructure is roughly 2.5
days old. It's kind of a hack, but it should work for now. We can
improve it later if needed.

TRAINTECH-614 #resolved #time 4h