### PR TITLE
Fixed regex that determines role from servername

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,10 +71,10 @@ class classroom::params {
   $courseware_source = '/home/training/courseware'
 
   $role = $::hostname ? {
-    /^master|classroom|puppetfactory$/ => 'master',
-    'proxy'                            => 'proxy',
-    'adserver'                         => 'adserver',
-    default                            => 'agent'
+    /^master$|^classroom$|^puppetfactory$/ => 'master',
+    'proxy'                                => 'proxy',
+    'adserver'                             => 'adserver',
+    default                                => 'agent'
   }
 
   $download = "\n\nPlease download a new VM: http://downloads.puppetlabs.com/training"


### PR DESCRIPTION
The old regex resulted in systems with the hostnames:
master123 (^master)
123classroom123 (classroom)
123puppetfactory (puppetfactory$)

All being wrongly assigned the role master. The updated regex correctly looks for master, classroom and puppetfactory exactly, with the previous examples being correctly identified as agents.