### PR TITLE
TRAINTECH-593 #resolved #time 1h

### DIFF
--- a/manifests/windows/disable_esc.pp
+++ b/manifests/windows/disable_esc.pp
@@ -14,4 +14,14 @@ class classroom::windows::disable_esc {
     type  => dword,
     data  => '0',
   }
+  
+  # The settings don't take effect without logging out or restarting explorer.
+  # In general this is a code smell and should be avoided.
+  # The only reason to do it here is to make things run smoothly in the classroom.
+  exec { 'restart explorer to disable IEESC':
+    command     => '$(Stop-Process -Name Explorer)',
+    provider    => 'powershell',
+    subscribe   => [Registry::Value['IE_ESC_users'], Registry::Value['IE_ESC_admin']],
+    refreshonly => true,
+  }
 }


### PR DESCRIPTION
TRAINTECH-593 #resolved #time 1h

I added the comment in case students look at this code.  It's a bad practice to restart explorer.exe, but in this case I think it's ok because we're trying to streamline the classroom setup.