### PR TITLE
This corrects the permission problem

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,11 +23,12 @@
 # $role      : What classroom role this node should play
 #
 class classroom (
-  $offline      = $classroom::params::offline,
-  $role         = $classroom::params::role,
-  $manageyum    = $classroom::params::manageyum,
-  $managerepos  = $classroom::params::managerepos,
-  $time_servers = $classroom::params::time_servers,
+  $offline        = $classroom::params::offline,
+  $role           = $classroom::params::role,
+  $manageyum      = $classroom::params::manageyum,
+  $managerepos    = $classroom::params::managerepos,
+  $manage_selinux = $classroom::params::manageselinux,
+  $time_servers   = $classroom::params::time_servers,
 ) inherits classroom::params {
   validate_bool($offline)
   validate_bool($manageyum)

--- a/manifests/master/showoff.pp
+++ b/manifests/master/showoff.pp
@@ -1,10 +1,13 @@
 class classroom::master::showoff (
-  String $courseware_source = $classroom::params::courseware_source,
+  String $training_user = $classroom::params::training_user,
 ) inherits classroom::params {
   include stunnel
   require classroom::master::dependencies::rubygems
   require showoff
   require classroom::master::pdf_stack
+
+  # where the source files are uploaded by the instructor's tooling
+  $courseware_source = "/home/${training_user}/courseware"
 
   # We use this resource so that any time an instructor uploads new content,
   # the PDF files will be rebuilt via the dependent exec statement
@@ -23,7 +26,7 @@ class classroom::master::showoff (
   # The rake task will upload content to this dir for the presentation.
   file { $courseware_source:
     ensure => directory,
-    owner   => $showoff::user,
+    owner   => $training_user,
     mode    => '0644',
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,9 +66,12 @@ class classroom::params {
   $r10k_remote  = '/root/environments'
   $r10k_basedir = "${confdir}/environments"
 
-  # Setup for Puppetfactory classes
-  $session_id        = '12345'
-  $courseware_source = '/home/training/courseware'
+  # Default session ID for Puppetfactory classes
+  $session_id    = '12345'
+
+  # Showoff and printing stack configuration
+  $training_user  = 'training'
+  $manage_selinux = true
 
   $role = $::hostname ? {
     /^(master|classroom|puppetfactory)$/ => 'master',


### PR DESCRIPTION
This allows the instructor to upload training material as the training
user. This should be all that remains to get the showoff/wk/pdftk stack
on every master. This has been tested with
fundamentals/practitioner/architect online. After we get a new VM build
out, it should also be tested offline to ensure that we've got all the
necessary packages cached.

This also parameterizes the username of the training user instead of the source.

TRAINTECH-660 #resolved #time 3h