### PR TITLE
Make PDF build idempotent

### DIFF
--- a/manifests/master/showoff.pp
+++ b/manifests/master/showoff.pp
@@ -34,7 +34,8 @@ class classroom::master::showoff (
     command     => "rake watermark target=_files/share",
     cwd         => "${showoff::root}/courseware/",
     path        => '/bin:/usr/bin:/usr/local/bin',
-    environment => ['HOME=/root'],
+    user        => $showoff::user,
+    environment => ['HOME=/tmp'],
     refreshonly => true,
   }
 


### PR DESCRIPTION
This creates the PDF files with the proper permissions in the first place,
therefore avoiding the infinite loop of changes triggering new builds that
will have their ownership changed on the next run again.

TRAINTECH-686 #resolved #time 30m