### PR TITLE
Include logging script on showoff enabled machines

### DIFF
--- a/manifests/master/showoff.pp
+++ b/manifests/master/showoff.pp
@@ -74,5 +74,8 @@ class classroom::master::showoff (
       ensure => present,
     }
   }
+  
+  # TODO: this belongs in the master class, but should wait until we put the stack on all masters
+  include classroom::master::perf_logging
 
 }


### PR DESCRIPTION
This belongs on all masters, but depends on the "remote presentation" workflow.
When we get that ported to all courses, this should move to the master class.

TRAINTECH-701 #resolved #time 30m