### PR TITLE
Adding the validate_erb, validate_yaml alias functions for powershell

### DIFF
--- a/files/windows/alias.psm1
+++ b/files/windows/alias.psm1
@@ -1,0 +1,21 @@
+## Name: C:\Users\Administrator\Documents\WindowsPowerShell\Modules\alias\alias.psm1
+
+Function validate_erb_func {
+ [CmdletBinding()]
+   Param($arg)
+   $pwd = Get-Location
+   $filename = "$pwd\$arg"
+   $command = 'erb -P -x -T - $filename | ruby -c'
+   iex "& $command"
+}; Set-Alias validate_erb validate_erb_func
+
+Function validate_yaml_func {
+ [CmdletBinding()]
+   Param($arg)
+   $pwd = Get-Location
+   $filename = "$pwd\$arg"
+   $command = 'ruby -ryaml -e "YAML.load_file ''$filename''"'
+   iex "& $command"
+}; Set-Alias validate_yaml validate_yaml_func
+
+export-modulemember -alias * -function *

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -16,6 +16,9 @@ class classroom::windows {
   include classroom::windows::geotrust
   include classroom::windows::password_policy
   include classroom::windows::disable_esc
+  include classroom::windows::alias
+
+  windows_env { 'PATH=C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin' : }
 
   include userprefs::npp
 

--- a/manifests/windows/alias.pp
+++ b/manifests/windows/alias.pp
@@ -11,15 +11,18 @@ class classroom::windows::alias {
     ensure => directory,
   }
 
-  file {"${alias_dir}/${psm_file}" :
+  file { 'alias_psd':
     ensure  => file,
     source  => "puppet:///modules/classroom/windows/${psm_file}",
+    path		=> "${alias_dir}/${psm_file}"
   }
 
   exec { "create_ps_datafile":
-    command   => "New-ModuleManifest -Path ${alias_dir}/${psd_file} -ModuleToProcess ${alias_dir}/${psm_file}; Import-Module alias",
-    creates   => "${alias_dir}/${psd_file}",
-    provider  => powershell,
+    command     => "New-ModuleManifest -Path ${alias_dir}/${psd_file} -ModuleToProcess ${alias_dir}/${psm_file}; Import-Module alias",
+    creates     => "${alias_dir}/${psd_file}",
+    refreshonly => true,
+    provider    => powershell,
+    subscribe   => File['alias_psd'],
   }
 
 }

--- a/manifests/windows/alias.pp
+++ b/manifests/windows/alias.pp
@@ -1,0 +1,25 @@
+class classroom::windows::alias {
+
+  assert_private('This class should not be called directly')
+
+  $ps_module_path = 'C:/Users/Administrator/Documents/WindowsPowerShell/Modules'
+  $alias_dir      = "${ps_module_path}/alias"
+  $psm_file       = 'alias.psm1'
+  $psd_file       = 'alias.psd1'
+
+  file { [$ps_module_path, $alias_dir] :
+    ensure => directory,
+  }
+
+  file {"${alias_dir}/${psm_file}" :
+    ensure  => file,
+    source  => "puppet:///modules/classroom/windows/${psm_file}",
+  }
+
+  exec { "create_ps_datafile":
+    command   => "New-ModuleManifest -Path ${alias_dir}/${psd_file} -ModuleToProcess ${alias_dir}/${psm_file}; Import-Module alias",
+    creates   => "${alias_dir}/${psd_file}",
+    provider  => powershell,
+  }
+
+}


### PR DESCRIPTION
Creating the equivalent alias functions so that validate_erb and validate_yaml can be used on windows machines as well