### PR TITLE
Add puppet-staging to requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,5 +68,6 @@
     {"name":"puppet/download_file",           "version_requirement":">= 1.0.0"},
     {"name":"puppet/iis",                     "version_requirement":">= 2.0.0"},
     {"name":"puppet/windowsfeature",          "version_requirement":">= 1.0.0"}
+    {"name":"puppet/staging",                 "version_requirement":">= 2.0.1"}
   ]
 }


### PR DESCRIPTION
The puppet-staging module is used by:
 `manifests/windows/adserver.pp`

Currently, the module seems to be pulled in as a dependency of
some other module. We should not count on that, and should add a
dependency to the module. This PR does that.

This does not require an immediate module release.