### PR TITLE
Added required control_owner param to courses using the GH editor

### DIFF
--- a/manifests/course/puppetize.pp
+++ b/manifests/course/puppetize.pp
@@ -1,5 +1,6 @@
 # This is a wrapper class to include all the bits needed for Puppetizing infrastructure
 class classroom::course::puppetize (
+  $control_owner,
   $offline      = $classroom::params::offline,
   $session_id   = $classroom::params::session_id,
 ) inherits classroom::params {
@@ -35,8 +36,9 @@ class classroom::course::puppetize (
     }
 
     class { 'classroom::master::codemanager':
-      control_repo => 'classroom-control-pi.git',
-      offline      => $offline,
+      control_owner => $control_owner,
+      control_repo  => 'classroom-control-pi.git',
+      offline       => $offline,
     }
 
   } elsif $::osfamily == 'windows' {

--- a/manifests/course/virtual/fundamentals.pp
+++ b/manifests/course/virtual/fundamentals.pp
@@ -1,4 +1,5 @@
 class classroom::course::virtual::fundamentals (
+  $control_owner,
   $offline    = $classroom::params::offline,
   $session_id = $classroom::params::session_id,
 ) inherits classroom::params {
@@ -28,8 +29,9 @@ class classroom::course::virtual::fundamentals (
     }
 
     class { 'classroom::master::codemanager':
-      control_repo     => 'classroom-control-vf.git',
-      offline          => $offline,
+      control_owner => $control_owner,
+      control_repo  => 'classroom-control-vf.git',
+      offline       => $offline,
     }
 
   }


### PR DESCRIPTION
The default value was puppetlabs-education, and now it must be
specified so the instructor's cloned repository is used instead.