### PR TITLE
control owner isn't required for VF

### DIFF
--- a/manifests/course/virtual/fundamentals.pp
+++ b/manifests/course/virtual/fundamentals.pp
@@ -1,7 +1,7 @@
 class classroom::course::virtual::fundamentals (
-  $control_owner,
-  $offline    = $classroom::params::offline,
-  $session_id = $classroom::params::session_id,
+  $control_owner = undef,
+  $offline       = $classroom::params::offline,
+  $session_id    = $classroom::params::session_id,
 ) inherits classroom::params {
   if $role == 'master' {
     File {


### PR DESCRIPTION
While we're still doing a repo per student, the control repo is the `puppet-education` one.