### PR TITLE
correct path

### DIFF
--- a/manifests/windows/adserver.pp
+++ b/manifests/windows/adserver.pp
@@ -111,7 +111,7 @@ class classroom::windows::adserver {
 
   # Download install for brackets lab
   class { 'staging':
-    path    => 'C:/shares/',
+    path    => 'C:/shares',
   }
   staging::file { 'Brackets.msi':
     source  => 'https://github.com/adobe/brackets/releases/download/release-1.3/Brackets.Release.1.3.msi',


### PR DESCRIPTION
I think something in Puppet internals has gotten more explicit with how paths are resolved. I've been seeing reports of errors resembling this one that @josephoaks saw in the classroom today.

```
Failed to apply catalog: Cannot alias File[C:/shares//classroom] to ["C:/shares/classroom"] at 
/etc/puppetlabs/code/modules/staging/manifests/file.pp:39; resource ["File", "C:/shares/classroom"]
already declared at /etc/puppetlabs/code/modules/classroom/manifests/windows/adserver.pp:123
```