### PR TITLE
Fully manage sources.yaml when we can.

### DIFF
--- a/manifests/master/codemanager.pp
+++ b/manifests/master/codemanager.pp
@@ -1,5 +1,6 @@
 class classroom::master::codemanager (
   $control_repo     = undef,
+  $repo_model       = $classroom::params::repo_model,
   $offline          = $classroom::params::offline,
   $control_owner    = $classroom::params::control_owner,
 ) inherits classroom::params {
@@ -26,10 +27,14 @@ class classroom::master::codemanager (
       value   => { 'remote' => "${gitserver}/${control_owner}/${control_repo}" },
     }
 
+    $replace = $repo_model ? {
+      'single'  => true,
+      'peruser' => false, # the puppetfactory hook must be able to update this list!
+    }
     # duplicated in a hiera datasource. because reasons.
     file { "${hieradata}/sources.yaml":
       ensure  => file,
-      replace => false, # the puppetfactory hook must be able to update this list!
+      replace => $replace,
       content => epp('classroom/hiera/data/sources.yaml.epp', {
                                         'gitserver'     => $gitserver,
                                         'control_owner' => $control_owner,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,7 @@ class classroom::params {
   # git configuration for the web-based alternative git workflow
   $usersuffix       = 'puppetlabs.vm'
   $control_owner    = 'puppetlabs-education'
+  $repo_model       = 'single'
   $gitserver        = {
     'online'  => 'https://github.com',
     'offline' => 'https://master.puppetlabs.vm:3000',


### PR DESCRIPTION
Set `replace => true` on the `sources.yaml` file which iterates the
control-repo sources unless we're running in a peruser repo model.