### PR TITLE
Install zlib-devel for nokogiri compile

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -14,6 +14,12 @@ class classroom::master {
     target => '/usr/bin/pip',
   }
 
+  # zlib-devel is require for nokogiri
+  package { 'zlib-devel':
+    ensure => present,
+    before => Class['showoff'],
+  }
+
   # Add the installer files for student agents
   # These files are cached by the build, so this will work offline
   include pe_repo::platform::el_6_i386


### PR DESCRIPTION
This got moved to the bootstrap module, but the build hasn't been updated yet.