### PR TITLE
Map puppetcode dir for 1st module testing

### DIFF
--- a/manifests/course/virtual/first_module.pp
+++ b/manifests/course/virtual/first_module.pp
@@ -9,7 +9,7 @@ class classroom::course::virtual::first_module (
 
     class { 'puppetfactory':
       plugins          => [ "Certificates", "Classification", "ConsoleUser", "Docker", "Logs", "ShellUser", "UserEnvironment" ],
-      puppetcode       => '/var/puppetcode',
+      puppetcode       => $classroom::params::testdir,
       modulepath       => 'readwrite',
       usersuffix       => $classroom::params::usersuffix,
       session          => $session_id,

--- a/manifests/course/virtual/first_module.pp
+++ b/manifests/course/virtual/first_module.pp
@@ -9,7 +9,7 @@ class classroom::course::virtual::first_module (
 
     class { 'puppetfactory':
       plugins          => [ "Certificates", "Classification", "ConsoleUser", "Docker", "Logs", "ShellUser", "UserEnvironment" ],
-      puppetcode       => $classroom::params::workdir,
+      puppetcode       => '/var/puppetcode',
       modulepath       => 'readwrite',
       usersuffix       => $classroom::params::usersuffix,
       session          => $session_id,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class classroom::params {
   }
   else {
     $workdir = '/root/puppetcode'
-    $testdir = '/root/puppetcode'
+    $testdir = '/var/puppetcode'
     $confdir = '/etc/puppetlabs/puppet'
     $codedir = '/etc/puppetlabs/code'
     $factdir = '/etc/puppetlabs/facter'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,12 +5,14 @@ class classroom::params {
   if $::osfamily == 'windows' {
     # Path to the student's working directory
     $workdir = 'C:/puppetcode'
+    $testdir = 'C:/temp'
     $confdir = 'C:/ProgramData/PuppetLabs/puppet/etc'
     $factdir = 'C:/ProgramData/PuppetLabs/facter'
     $codedir = 'C:/ProgramData/PuppetLabs/code'
   }
   else {
     $workdir = '/root/puppetcode'
+    $testdir = '/root/puppetcode'
     $confdir = '/etc/puppetlabs/puppet'
     $codedir = '/etc/puppetlabs/code'
     $factdir = '/etc/puppetlabs/facter'


### PR DESCRIPTION
'/root/puppetcode' is the default, but it's not used in the course. This maps '/var/puppetcode' instead as a convenient way of getting the solutions to the container for the acceptance test while not distracting the students in class.