### PR TITLE
Change ignore pattern so PMT honors it too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ junit/*
 .vagrant
 Gemfile.lock
 .bundle/
-spec/fixtures/modules
-spec/fixtures/manifests
+spec/fixtures/


### PR DESCRIPTION
With this pattern, `puppet module build` will honor the rules and omit fixtures from the published tarball.