### PR TITLE
Change recurse method

### DIFF
--- a/manifests/master/showoff.pp
+++ b/manifests/master/showoff.pp
@@ -16,7 +16,7 @@ class classroom::master::showoff (
     ensure  => directory,
     owner   => $showoff::user,
     mode    => '0644',
-    recurse => true,
+    recurse => remote,
     source  => $courseware_source,
     notify  => Exec['build_pdfs'],
     require => File[$courseware_source],


### PR DESCRIPTION
When setting this to `remote`, Puppet will manage the files that exist in the remote source, but not the files that don't. This means that it will stop trying to change the permissions of the files that are created by Showoff and Puppetfactory. *\o/*

TRAINTECH-765 #resolved #time 1h