### PR TITLE
Pin to a known good version of nokogiri

### DIFF
--- a/manifests/master/dependencies/rubygems.pp
+++ b/manifests/master/dependencies/rubygems.pp
@@ -11,4 +11,14 @@ class classroom::master::dependencies::rubygems {
     ensure   => present,
     provider => puppet_gem,
   }
+  
+  # The new nokogiri won't run on RHEL or CentOS. Because reasons.
+  # https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#170--2016-12-26
+  package { 'nokogiri':
+    ensure   => '1.6.8.1',
+    provider => gem,
+  }
+  # This is a soft relationship. It won't fail if showoff isn't included.
+  Package['nokogiri'] -> Package<| title == 'showoff' |>
+  
 }


### PR DESCRIPTION
They cut a release the day after christmas dropping support for the default Ruby in RHEL & CentOS. Dumdums.
https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#170--2016-12-26

TRAINVM-338 #resolved #time 25m