### PR TITLE
WIP: can reuse puppet master's ssl certificates

### DIFF
--- a/manifests/master/showoff.pp
+++ b/manifests/master/showoff.pp
@@ -1,5 +1,6 @@
 class classroom::master::showoff (
-  String $training_user = $classroom::params::training_user,
+  String  $training_user = $classroom::params::training_user,
+  Boolean $stunnel       = true,
 ) inherits classroom::params {
   include stunnel
   require classroom::master::dependencies::rubygems
@@ -44,21 +45,62 @@ class classroom::master::showoff (
     subscribe => File["${showoff::root}/courseware"],
   }
 
-  file { '/etc/stunnel/showoff.pem':
-    ensure => 'file',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0600',
-    source => 'puppet:///modules/classroom/showoff.pem',
-    before => Stunnel::Tun['showoff-ssl'],
-  }
+  # Gate it behind this boolean for a soft launch.
+  # After more testing, we'll turn it on for all classes.
+  # (will require messaging updates in the Rakefile as well)
+  # TODO: This requires the certificate to be accepted permanently. Likely a dealbreaker.
+  if $stunnel {
+    file { '/etc/stunnel/showoff.pem':
+      ensure => 'file',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0600',
+      source => 'puppet:///modules/classroom/showoff.pem',
+      before => Stunnel::Tun['showoff-ssl'],
+    }
 
-  stunnel::tun { 'showoff-ssl':
-    accept  => '9091',
-    connect => 'localhost:9090',
-    options => 'NO_SSLv2',
-    cert    => '/etc/stunnel/showoff.pem',
-    client  => false,
+    stunnel::tun { 'showoff-ssl':
+      accept  => '9091',
+      connect => 'localhost:9090',
+      options => 'NO_SSLv2',
+      cert    => '/etc/stunnel/showoff.pem',
+      client  => false,
+    }
+  }
+  else {
+    file { '/etc/showoff':
+      ensure => directory,
+      owner  => $showoff::user,
+      mode   => '0755',
+    }
+    file { "/etc/showoff/${clientcert}.pem":
+      ensure => file,
+      owner  => $showoff::user,
+      mode   => '0644',
+      source => "${settings::ssldir}/certs/master.puppetlabs.vm.pem"
+    }
+    file { "/etc/showoff/${clientcert}.key":
+      ensure => file,
+      owner  => $showoff::user,
+      mode   => '0600',
+      source => "${settings::ssldir}/private_keys/master.puppetlabs.vm.pem"
+    }
+
+    augeas{ "enable showoff ssl":
+      incl    => "${courseware_source}/showoff.json",
+      lens    => 'Json.lns',
+      context => "/files/${courseware_source}/showoff.json",
+      changes => [
+        "set dict/entry[last()+1] ssl",
+        "set dict/entry[last()+1] ssl_certificate",
+        "set dict/entry[last()+1] ssl_private_key",
+        "set dict/entry[.='ssl']/const true",
+        "set dict/entry[.='ssl_certificate']/string /etc/showoff/${clientcert}.pem",
+        "set dict/entry[.='ssl_private_key']/string /etc/showoff/${clientcert}.key",
+      ],
+      onlyif  => "match dict/entry[.='ssl'] size == 0",
+      before  => File["${showoff::root}/courseware"],
+    }
   }
 
   if $classroom::manage_selinux {


### PR DESCRIPTION
This allows the presentation to use the same certificates as the Puppet
Console does. This means that the student would only need to accept a
single certificate for the classroom.

Don't merge yet, because for follow mode, or other interactivity, the
audience has to accept the certificate **permanently** and I'm not sure
that's good UX. I'm still looking for a way to get around that :-/