### PR TITLE
use local IP instead of name

### DIFF
--- a/manifests/master/showoff.pp
+++ b/manifests/master/showoff.pp
@@ -55,7 +55,7 @@ class classroom::master::showoff (
 
   stunnel::tun { 'showoff-ssl':
     accept  => '9091',
-    connect => 'localhost:9090',
+    connect => '127.0.0.1:9090',
     options => 'NO_SSLv2',
     cert    => '/etc/stunnel/showoff.pem',
     client  => false,


### PR DESCRIPTION
We're seeing the localhost alias broken too often lately