### PR TITLE
(TRAINTECH-964): Fix JMX metrics scripts

### DIFF
--- a/files/metrics/metrics/list_all_puppet_metrics.rb
+++ b/files/metrics/metrics/list_all_puppet_metrics.rb
@@ -4,7 +4,7 @@ require 'jmx'
 
 client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
 
-metric_names = client.query_names("metrics:*")
+metric_names = client.query_names("puppetserver:*")
 metric_names.each do |metric_name|
    name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")
    if name_property.start_with?("puppetlabs.")

--- a/files/metrics/metrics/puppet_function_stats.rb
+++ b/files/metrics/metrics/puppet_function_stats.rb
@@ -5,7 +5,7 @@ require 'table_print'
 
 client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
 
-metric_names = client.query_names("metrics:*")
+metric_names = client.query_names("puppetserver:*")
 functions = []
 metric_names.each do |metric_name|
    name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")

--- a/files/metrics/metrics/puppet_http_stats.rb
+++ b/files/metrics/metrics/puppet_http_stats.rb
@@ -12,9 +12,9 @@ end
 
 def metric_name(name)
   if name =~ /\A[\w.-]+\z/
-    "metrics:name=puppetlabs.#{MetricsId}.#{name}"
+    "puppetserver:name=puppetlabs.#{MetricsId}.#{name}"
   else
-    "metrics:name=\"puppetlabs.#{MetricsId}.#{name}\""
+    "puppetserver:name=\"puppetlabs.#{MetricsId}.#{name}\""
   end
 end
 

--- a/files/metrics/metrics/puppet_resource_eval_stats.rb
+++ b/files/metrics/metrics/puppet_resource_eval_stats.rb
@@ -5,7 +5,7 @@ require 'table_print'
 
 client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
 
-metric_names = client.query_names("metrics:*")
+metric_names = client.query_names("puppetserver:*")
 resources = []
 metric_names.each do |metric_name|
    name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")


### PR DESCRIPTION
The metric names/headers changed from 'metrics:*' to 'puppetserver:*'
This restores the puppetserver_metrics examples/labs to working
condition.