### PR TITLE
Increasing timeout

### DIFF
--- a/manifests/windows/adserver.pp
+++ b/manifests/windows/adserver.pp
@@ -48,7 +48,7 @@ class classroom::windows::adserver {
     command     => "Import-Module ADDSDeployment; Install-ADDSForest -Force -DomainName ${classroom::ad_domainname} -DomainMode 6 -DomainNetbiosName ${classroom::ad_netbiosdomainname} -ForestMode 6 -DatabasePath c:\\windows\\ntds -LogPath c:\\windows\\ntds -SysvolPath c:\\windows\\sysvol -SafeModeAdministratorPassword (convertto-securestring '${classroom::ad_dsrmpassword}' -asplaintext -force) -InstallDns",
     provider    => powershell,
     onlyif      => "if((gwmi WIN32_ComputerSystem).Domain -eq \'${classroom::ad_domainname}\'){exit 1}",
-    timeout     => '0',
+    timeout     => '1800',
     before      => Exec['SetMachineQuota'],
   }
 

--- a/manifests/windows/adserver.pp
+++ b/manifests/windows/adserver.pp
@@ -48,7 +48,7 @@ class classroom::windows::adserver {
     command     => "Import-Module ADDSDeployment; Install-ADDSForest -Force -DomainName ${classroom::ad_domainname} -DomainMode 6 -DomainNetbiosName ${classroom::ad_netbiosdomainname} -ForestMode 6 -DatabasePath c:\\windows\\ntds -LogPath c:\\windows\\ntds -SysvolPath c:\\windows\\sysvol -SafeModeAdministratorPassword (convertto-securestring '${classroom::ad_dsrmpassword}' -asplaintext -force) -InstallDns",
     provider    => powershell,
     onlyif      => "if((gwmi WIN32_ComputerSystem).Domain -eq \'${classroom::ad_domainname}\'){exit 1}",
-    timeout     => '1800',
+    timeout     => '600',
     before      => Exec['SetMachineQuota'],
   }
 


### PR DESCRIPTION
When executing the Config ADDS line, it translates the timeout of 0 as 0, and assumes 50ms timeout, which causes the command to fail.  Upping to 1800s allows it to finish successfully.

You can verify this issue by running puppet agent -t --debug --trace and looking at the powershell output when executing a powershell session.