### PR TITLE
Using PQL to grab DNS ipaddress

### DIFF
--- a/manifests/windows/dns_server.pp
+++ b/manifests/windows/dns_server.pp
@@ -1,18 +1,13 @@
 # Set a DNS server on the windows agents
 define classroom::windows::dns_server (
-  $adserver_ip_query = 'facts[value]{name = "ipaddress" and certname = "adserver"}',
-  $adserver_ip_lookup = puppetdb_query($adserver_ip_query)
   $ip = '8.8.8.8',
 ) {
-  $adserver_ip = $adserver_ip_lookup ? {
-    Array   => $adserver_ip_lookup[0][value],
-    default => '8.8.4.4',
     }
     # Only run on windows
     if $::osfamily  == 'windows' {
       exec { 'set_dns':
-        command  => "set-DnsClientServerAddress -interfacealias Ethernet0 -serveraddresses ${adserver_ip}, ${ip}",
-        unless   => "if ((Get-DnsClientServerAddress -addressfamily ipv4 -interfacealias Ethernet0).serveraddresses -notcontains '${adserver_ip}'){exit 1}",
+        command  => "set-DnsClientServerAddress -interfacealias Ethernet0* -serveraddresses ${ip}",
+        unless   => "if ((Get-DnsClientServerAddress -addressfamily ipv4 -interfacealias Ethernet0*).serveraddresses -ne '${ip}'){exit 1}",
         provider => powershell,
       }
     }

--- a/manifests/windows/dns_server.pp
+++ b/manifests/windows/dns_server.pp
@@ -1,13 +1,18 @@
 # Set a DNS server on the windows agents
 define classroom::windows::dns_server (
-  $adserver_ip = 'facts[value]{name = "ipaddress" and certname = "adserver"},
+  $adserver_ip_query = 'facts[value]{name = "ipaddress" and certname = "adserver"}',
+  $adserver_ip_lookup = puppetdb_query($adserver_ip_query)
   $ip = '8.8.8.8',
 ) {
+  $adserver_ip = $adserver_ip_lookup ? {
+    Array   => $adserver_ip_lookup[0][value],
+    default => '8.8.4.4',
+    }
     # Only run on windows
     if $::osfamily  == 'windows' {
       exec { 'set_dns':
-        command  => "set-DnsClientServerAddress -interfacealias Ethernet0 -serveraddresses ${adserver_ip[0][value]}, ${ip}",
-        unless   => "if ((Get-DnsClientServerAddress -addressfamily ipv4 -interfacealias Ethernet0).serveraddresses -notcontains '${adserver_ip[0][value]}'){exit 1}",
+        command  => "set-DnsClientServerAddress -interfacealias Ethernet0 -serveraddresses ${adserver_ip}, ${ip}",
+        unless   => "if ((Get-DnsClientServerAddress -addressfamily ipv4 -interfacealias Ethernet0).serveraddresses -notcontains '${adserver_ip}'){exit 1}",
         provider => powershell,
       }
     }

--- a/manifests/windows/dns_server.pp
+++ b/manifests/windows/dns_server.pp
@@ -1,12 +1,13 @@
 # Set a DNS server on the windows agents
 define classroom::windows::dns_server (
+  $adserver_ip = 'facts[value]{name = "ipaddress" and certname = "adserver"},
   $ip = '8.8.8.8',
 ) {
     # Only run on windows
     if $::osfamily  == 'windows' {
       exec { 'set_dns':
-        command  => "set-DnsClientServerAddress -interfacealias Ethernet0 -serveraddresses ${ip}",
-        unless   => "if ((Get-DnsClientServerAddress -addressfamily ipv4 -interfacealias Ethernet0).serveraddresses -ne '${ip}'){exit 1}",
+        command  => "set-DnsClientServerAddress -interfacealias Ethernet0 -serveraddresses ${adserver_ip[0][value]}, ${ip}",
+        unless   => "if ((Get-DnsClientServerAddress -addressfamily ipv4 -interfacealias Ethernet0).serveraddresses -notcontains '${adserver_ip[0][value]}'){exit 1}",
         provider => powershell,
       }
     }


### PR DESCRIPTION
Since joining a domain requires the dns resolver to find the MS DNS records, this requires looking up the ipaddress of the AD DNS server, and then setting it as the DNS server.

This assumes that the AD server for the class always has the certname of adserver.  An alternative would be to do a lookup of a class that only ever gets assigned to the ad server.

Once DSC is fully integrated, it'd be best to use an exported resource from that, but this solves the issue until then.


This also updates the unless to check for the ad ipaddress, since as long as that is there we don't care so much about the rest.