### PR TITLE
cmake is now a dependency

### DIFF
--- a/manifests/master/dependencies/rubygems.pp
+++ b/manifests/master/dependencies/rubygems.pp
@@ -2,7 +2,7 @@ class classroom::master::dependencies::rubygems {
   assert_private('This class should not be called directly')
 
   # These are required by rubygems compiling native code
-  package { ['gcc', 'zlib', 'zlib-devel']:
+  package { ['cmake3', 'gcc', 'zlib', 'zlib-devel']:
     ensure => present,
   }
 


### PR DESCRIPTION
because we pinned to a known good version, commonmarker is now a hard dependency of showoff. It requires cmake to compile the native libcmark code.

Because showoff is cached on the VM along with the other gems & packages, I don't actually think this is a critical fix. But we should ensure it's available on the next VM update.