### PR TITLE
Manage hiera & hiera_explain on all virtual nodes

### DIFF
--- a/files/hiera_explain.rb
+++ b/files/hiera_explain.rb
@@ -1,0 +1,85 @@
+#! /opt/puppetlabs/puppet/bin/ruby
+require 'hiera'
+
+# Use MCO's fact cache because all nodes will have them
+scope = YAML.load_file("/etc/puppetlabs/mcollective/facts.yaml")
+hiera = Hiera.new(:config => "/etc/puppetlabs/puppet/hiera.yaml")
+scope['environment'] ||= 'production'
+
+# data buckets
+priority_lookup = {}
+array_lookup    = {}
+hash_lookup     = {}
+hash_errors     = {}
+
+# Cribbed from Hiera source to ensure we're parsing the same way.
+unless ARGV.empty?
+  ARGV.each do |arg|
+    if arg =~ /^(.+?)=(.+?)$/
+      scope[$1] = $2
+    else
+      STDERR.puts "Don't know how to parse scope argument: #{arg}"
+    end
+  end
+end
+
+puts 'Backend data directories:'
+Hiera::Config[:backends].each do |backend|
+  puts "  * #{backend}: #{Hiera::Backend.datadir(backend, scope)}"
+end
+puts
+
+puts 'Expanded hierarchy:'
+Hiera::Backend.datasources(scope) do |datasource|
+  puts "  * #{datasource}"
+end
+puts
+
+puts 'File lookup order:'
+Hiera::Config[:backends].each do |backend|
+  datadir = Hiera::Backend.datadir(backend, scope)
+  next unless datadir
+
+  Hiera::Backend.datasources(scope) do |source|
+    path   = File.join(datadir, "#{source}.#{backend}")
+    status = File.exists?(path) ? '[X]' : '[ ]'
+    puts "  #{status} #{path}"
+
+    data = YAML.load_file(path) rescue {}
+    priority_lookup = data.merge(priority_lookup)
+
+    data.each do |key, value|
+      array_lookup[key] ||= Array.new
+      array_lookup[key] << value
+
+      hash_lookup[key] ||= Hash.new
+      if (value.class == Hash)
+        hash_lookup[key].merge!(value)
+      else
+        hash_errors[key] ||= Array.new
+        hash_errors[key]  << "#{source}.#{backend}"
+      end
+    end
+
+  end
+end
+puts
+
+puts 'Priority lookup results:'
+priority_lookup.each { |key, value| puts "   * hiera('#{key}') => #{value}" }
+puts
+
+puts 'Array lookup results:'
+array_lookup.each { |key, value| puts "   * hiera_array('#{key}') => #{value.inspect}" }
+puts
+
+puts 'Hash lookup results:'
+hash_lookup.each do |key, value|
+  print "   * hiera_hash('#{key}') => "
+  if(hash_errors.has_key? key)
+    puts "No hash datatype in #{hash_errors[key].inspect}"
+  else
+    puts value.inspect
+  end
+end
+puts

--- a/manifests/agent/hiera.pp
+++ b/manifests/agent/hiera.pp
@@ -59,6 +59,14 @@ class classroom::agent::hiera {
     }
   }
 
+  file { '/usr/local/bin/hiera_explain.rb':
+    ensure => file,
+    owner => 'root',
+    group => 'root',
+    mode  => '0777',
+    source => 'puppet:///modules/classroom/hiera_explain.rb',
+  }
+
   file { "${hieradata}/common.yaml":
     ensure  => file,
     source  => 'puppet:///modules/classroom/hiera/data/common.yaml',

--- a/manifests/course/virtual/fundamentals.pp
+++ b/manifests/course/virtual/fundamentals.pp
@@ -12,7 +12,6 @@ class classroom::course::virtual::fundamentals (
       mode  => '0644',
     }
 
-    include classroom::master::hiera
     include classroom::master::dependencies::dashboard
 
     class { 'puppetfactory':

--- a/manifests/course/virtual/practitioner.pp
+++ b/manifests/course/virtual/practitioner.pp
@@ -12,7 +12,6 @@ class classroom::course::virtual::practitioner (
       mode  => '0644',
     }
 
-    include classroom::master::hiera
     include classroom::master::dependencies::dashboard
 
     class { 'puppetfactory':

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -5,12 +5,13 @@ class classroom::virtual {
   if $classroom::params::role == 'master' {
     include classroom::master::dependencies::rubygems
     include classroom::master::showoff
+    include classroom::master::hiera
 
     # Configure performance logging
     include classroom::master::perf_logging
   } else {
     # if we ever have universal classification for virtual agents, it will go here
-
+    include classroom::agent::hiera
   }
 
   if $::osfamily == 'windows' {


### PR DESCRIPTION
This unifies how Hiera is managed for all classes, virtual and not. It
also puts the `hiera_explain.rb` script on all nodes for easier
debugging when running it locally. (currently only the case in
practitioner)

TRAINTECH-1087 #resolved #time 45m