### PR TITLE
Add openssl to agent nodes

### DIFF
--- a/manifests/agent/packages.pp
+++ b/manifests/agent/packages.pp
@@ -1,0 +1,9 @@
+class classroom::agent::packages {
+  $packages = [
+    'openssl',         # used for generating password hashes for user resources
+  ]
+
+  package { $packages:
+    ensure => present,
+  }
+}

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -10,7 +10,7 @@ class classroom::virtual {
     include classroom::master::perf_logging
   } else {
     # if we ever have universal classification for virtual agents, it will go here
-
+    include classroom::agent::packages
   }
 
   if $::osfamily == 'windows' {


### PR DESCRIPTION
This creates a new grab-bag class for misc. packages to be installed on
the agent. The `openssl` package is already cached on the master, so
this installs just fine.

TRAINTECH-1068 #resolved #time 30m