### PR TITLE
TRAINTECH-1094 Enabled and tested DSC resources

### DIFF
--- a/files/install_wmf5.ps1
+++ b/files/install_wmf5.ps1
@@ -1,16 +1,19 @@
-WriteOutput 'Setting up DSC components'
+#This script is only tested against and should only run on 2012R2 systems.
+#There are caveats and issues upgrading from WMF 3 to 5 on 2008R2/Win7 that
+#this script does not consider due to classroom environment being 2012R2.
+
+#Modifiable variables are below. Update these as needed to match the WMF
+#you want to have installed. Only update the DownloadUrl if Microsoft changes path.
+$wmfInstallerFile = 'Win8.1AndW2K12R2-KB3134758-x64.msu'
+$wmfDownloadUrl = "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/$wmfInstallerFile"
 
 $wmfPath = 'c:\temp'
-$systemModules = "$env:ProgramFiles\WindowsPowerShell\Modules"
-
-# Would you believe the space after the equals is required?!
-cmd /c "sc config wuauserv start= demand"
-
-# August 2015 Production Preview
-$wmfDownloadUrl = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win8.1AndW2K12R2-KB3066437-x64.msu'
-$wmfInstallerFile = 'Win8.1AndW2K12R2-KB3066437-x64.msu'
-
 $wmfInstaller = Join-Path $wmfPath $wmfInstallerFile
+
+Write-Output 'Setting up DSC components'
+
+# Running this command may not be necessary, but breaks nothing, presumably.
+cmd /c "sc config wuauserv start= demand"
 
 if (!(Test-Path $wmfPath)) {
   Write-Output "Creating folder `'$wmfPath`'"
@@ -21,12 +24,5 @@ if (!(Test-Path $wmfInstaller)) {
   Write-Output "Downloading `'$wmfDownloadUrl`' to `'$wmfInstaller`'"
     (New-Object Net.WebClient).DownloadFile("$wmfDownloadUrl","$wmfInstaller")
 }
-
-$psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.WorkingDirectory = "$wmfPath"
-$psi.FileName = "$wmfInstallerFile"
-$psi.Arguments = "/quiet" # /norestart /log `'$wmfPath\wmfInstall.log`'"
-#$psi.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Minimized;
-
-Write-Output "Installing `'$wmfInstaller`'"
-$s = [System.Diagnostics.Process]::Start($psi);
+Write-Output "Installing WMF 5.0"
+& $wmfInstaller /quiet /norestart

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,7 +59,7 @@ class classroom::params {
   # Windows active directory setup parameters
   $ad_domainname           = 'CLASSROOM.local'
   $ad_netbiosdomainname    = 'CLASSROOM'
-  $ad_dsrmpassword         = 'Puppetlabs1'
+  $ad_dsrmpassword         = 'PuppetLabs1'
 
   # Tuning parameters for classroom master performance
   $jruby_purge        = false    # See https://tickets.puppetlabs.com/browse/PE-9704

--- a/manifests/windows/adserver.pp
+++ b/manifests/windows/adserver.pp
@@ -8,61 +8,73 @@ class classroom::windows::adserver {
     provider => powershell,
   }
 
-  # Install AD Server feature
-#  dsc_windowsfeature { 'ADDSInstall':
-#    dsc_ensure => 'Present',
-#    dsc_name   => 'AD-Domain-Services',
-#    require    => [Exec['RequirePassword'],Exec['Install WMF5']],
-#  }
-
-  exec { "add-feature-adserver":
-    command   => "Import-Module ServerManager; Install-WindowsFeature AD-Domain-Services -IncludeManagementTools -IncludeAllSubFeature -Restart:\$true",
-    onlyif    => "Import-Module ServerManager; if (@(Get-WindowsFeature AD-Domain-Services | ?{\$_.Installed -match \'false\'}).count -eq 0) { exit 1 }",
-    provider  => powershell,
-    before    => Exec['Config ADDS'],
+  exec { 'Install WMF5':
+    command  => file('classroom/install_wmf5.ps1'),
+    unless   => 'if ($PSVersionTable.PSVersion.Major -ne 5){exit 1}',
+    provider => powershell,
+    notify   => Reboot['after_wmf5_install'],
   }
+
+  reboot { 'after_wmf5_install':
+    when => pending,
+  }
+  # Install AD Server feature
+  dsc_windowsfeature { 'ADDSInstall':
+    dsc_ensure => 'Present',
+    dsc_name   => 'AD-Domain-Services',
+    require    => [Exec['RequirePassword'],Exec['Install WMF5']],
+  }
+
+  #  exec { "add-feature-adserver":
+  #  command   => "Import-Module ServerManager; Install-WindowsFeature AD-Domain-Services -IncludeManagementTools -IncludeAllSubFeature -Restart:\$true",
+  #  onlyif    => "Import-Module ServerManager; if (@(Get-WindowsFeature AD-Domain-Services | ?{\$_.Installed -match \'false\'}).count -eq 0) { exit 1 }",
+  #  provider  => powershell,
+  #  before    => Exec['Config ADDS'],
+  #}
 
  # Setup Classroom Domain
-#  dsc_xaddomain { 'FirstDS':
-#    dsc_domainname                    => $classroom::ad_domainname,
-#    dsc_domainadministratorcredential => {'user' => 'Administrator', 'password' => $classroom::ad_dsrmpassword },
-#    dsc_safemodeadministratorpassword => {'user' => 'Administrator', 'password' => $classroom::ad_dsrmpassword },
-#    require                           => Dsc_windowsfeature['ADDSInstall'],
-#  }
+  dsc_xaddomain { 'FirstDS':
+    dsc_domainname                    => $classroom::ad_domainname,
+    dsc_domainadministratorcredential => {'user' => 'Administrator', 'password' => $classroom::ad_dsrmpassword },
+    dsc_safemodeadministratorpassword => {'user' => 'Administrator', 'password' => $classroom::ad_dsrmpassword },
+    require                           => Dsc_windowsfeature['ADDSInstall'],
+  }
 #
-#  reboot {'after_AD':
-#    subscribe => Dsc_xaddomain['FirstDS'],
-#    notify    => Dsc_xwaitforaddomain['DscForestWait'],
-#  }
+  reboot {'dsc_reboot':
+    #    subscribe => Dsc_xaddomain['FirstDS'],
+    #notify        => Dsc_xwaitforaddomain['DscForestWait'],
+    message        => 'DSC has requested a reboot',
+    when           => 'pending',
+  }
 #
-#  dsc_xwaitforaddomain { 'DscForestWait':
-#    dsc_domainname           => $classroom::ad_domainname,
-#    dsc_domainusercredential => {'user' => 'Administrator', 'password' => $classroom::ad_dsrmpassword },
-#    dsc_retrycount           => '50',
-#    dsc_retryintervalsec     => '30',
-#    require                  => Dsc_xaddomain['FirstDS']
-#  }
+  dsc_xwaitforaddomain { 'DscForestWait':
+    dsc_domainname           => $classroom::ad_domainname,
+    dsc_domainusercredential => {'user' => 'Administrator', 'password' => $classroom::ad_dsrmpassword },
+    dsc_retrycount           => '50',
+    dsc_retryintervalsec     => '30',
+    require                  => Dsc_xaddomain['FirstDS']
+  }
 #
 
-  exec { 'Config ADDS':
-    command     => "Import-Module ADDSDeployment; Install-ADDSForest -Force -DomainName ${classroom::ad_domainname} -DomainMode 6 -DomainNetbiosName ${classroom::ad_netbiosdomainname} -ForestMode 6 -DatabasePath c:\\windows\\ntds -LogPath c:\\windows\\ntds -SysvolPath c:\\windows\\sysvol -SafeModeAdministratorPassword (convertto-securestring '${classroom::ad_dsrmpassword}' -asplaintext -force) -InstallDns",
-    provider    => powershell,
-    onlyif      => "if((gwmi WIN32_ComputerSystem).Domain -eq \'${classroom::ad_domainname}\'){exit 1}",
-    timeout     => '0',
-    before      => Exec['SetMachineQuota'],
-  }
+#  exec { 'Config ADDS':
+#    command     => "Import-Module ADDSDeployment; Install-ADDSForest -Force -DomainName ${classroom::ad_domainname} -DomainMode 6 -DomainNetbiosName ${classroom::ad_netbiosdomainname} -ForestMode 6 -DatabasePath c:\\windows\\ntds -LogPath c:\\windows\\ntds -SysvolPath c:\\windows\\sysvol -SafeModeAdministratorPassword (convertto-securestring '${classroom::ad_dsrmpassword}' -asplaintext -force) -InstallDns",
+#    provider    => powershell,
+#    onlyif      => "if((gwmi WIN32_ComputerSystem).Domain -eq \'${classroom::ad_domainname}\'){exit 1}",
+#    timeout     => '0',
+#    before      => Exec['SetMachineQuota'],
+#  }
 
-  reboot { 'after ADDS':
-    subscribe => Exec['Config ADDS'],
-  }
+#  reboot { 'after ADDS':
+#    subscribe => Exec['Config ADDS'],
+#  }
 
   # Increase the number of machines that a single user can join to the domain
   exec { 'SetMachineQuota':
     command      => 'get-addomain |set-addomain -Replace @{\'ms-DS-MachineAccountQuota\'=\'99\'}',
     unless       => 'if ((get-addomain | get-adobject -prop \'ms-DS-MachineAccountQuota\' | select -exp \'ms-DS-MachineAccountQuota\') -lt 99) {exit 1}',
     provider     => powershell,
-    #    require => Dsc_xwaitforaddomain['DscForestWait'],
-    require      => Reboot['after ADDS'],
+        require => Dsc_xwaitforaddomain['DscForestWait'],
+    #    require      => Reboot['after_AD'],
   }
 
   exec { 'STUDENTS OU':
@@ -72,42 +84,42 @@ class classroom::windows::adserver {
     require  => Exec['SetMachineQuota']
   }
 
-#  dsc_xadgroup { 'WebsiteAdmins':
-#    dsc_groupname => $title,
-#    dsc_groupscope => 'Global',
-#    dsc_description => 'Web Admins',
-#    dsc_ensure      => 'Present',
-#  }
-  exec { 'Website Admins Group':
-    command     => "import-module activedirectory;New-ADGroup -Description 'Website Administrators' -DisplayName 'WebAdmins' -Name 'WebAdmins' -GroupCategory 'Security' -GroupScope 'Global' -Path 'CN=Users,DC=CLASSROOM,DC=LOCAL'",
-    onlyif      => "\$groupname = \"WebAdmins\";\$path = \"CN=Users,DC=CLASSROOM,DC=LOCAL\";\$oustring = \"CN=\$groupname,\$path\"; if([adsi]::Exists(\"LDAP://\$oustring\")){exit 1}",
-    provider    => powershell,
-    require     => Exec['STUDENTS OU'],
+  dsc_xadgroup { 'WebsiteAdmins':
+    dsc_groupname => 'WebsiteAdmins',
+    dsc_groupscope => 'Global',
+    dsc_description => 'Web Admins',
+    dsc_ensure      => 'Present',
+  }
+  #  exec { 'Website Admins Group':
+  #  command     => "import-module activedirectory;New-ADGroup -Description 'Website Administrators' -DisplayName 'WebAdmins' -Name 'WebAdmins' -GroupCategory 'Security' -GroupScope 'Global' -Path 'CN=Users,DC=CLASSROOM,DC=LOCAL'",
+  #  onlyif      => "\$groupname = \"WebAdmins\";\$path = \"CN=Users,DC=CLASSROOM,DC=LOCAL\";\$oustring = \"CN=\$groupname,\$path\"; if([adsi]::Exists(\"LDAP://\$oustring\")){exit 1}",
+  #  provider    => powershell,
+  #  require     => Exec['STUDENTS OU'],
+  #}
+
+  dsc_xaduser { 'admin':
+    dsc_domainname => $classroom::ad_domainname,
+    dsc_domainadministratorcredential =>
+      {
+        'user' => 'Administrator',
+        'password' => $classroom::ad_dsrmpassword,
+      },
+    dsc_username => 'admin',
+    dsc_password =>
+      {
+        'user' => 'admin',
+        'password' => 'M1Gr3atP@ssw0rd',
+      },
+    dsc_ensure => 'present',
+    require => Dsc_xwaitforaddomain['DscForestWait']
   }
 
-#  dsc_xaduser { 'admin':
-#    dsc_domainname                    => $classroom::ad_domainname,
-#    dsc_domainadministratorcredential =>
-#      {
-#        'user' => 'Administrator',
-#        'password' => $classroom::addsrmpassword,
-#      },
-#    dsc_username => 'admin',
-#    dsc_password =>
-#      {
-#        'user' => 'admin',
-#        'password' => 'M1Gr3atP@ssw0rd',
-#      },
-#    dsc_ensure => 'Present',
-#    require => Dsc_xwaitforaddomain['DscForestWait']
-#  }
-
-  exec { "Add User - admin":
-    command     => "import-module servermanager;add-windowsfeature -name 'rsat-ad-powershell' -includeAllSubFeature;import-module activedirectory;New-ADUser -name 'Classroom Admin' -DisplayName 'Classroom Admin' -GivenName 'Classroom' -SurName 'Admin' -Email 'admin@CLASSROOM.local' -Samaccountname 'admin' -UserPrincipalName 'admin@CLASSROOM.local' -Description 'Classroom Administrator' -PasswordNeverExpires \$true -path 'OU=STUDENTS,DC=CLASSROOM,DC=local' -AccountPassword (ConvertTo-SecureString 'Adm1nP@SSw0rd' -AsPlainText -force) -Enabled \$true;",
-    onlyif      => "\$oustring = \"CN=Classroom Admin,OU=STUDENTS,DC=CLASSROOM,DC=local\"; if([adsi]::Exists(\"LDAP://\$oustring\")){exit 1}",
-    provider    => powershell,
-    require     => Exec['STUDENTS OU'],
-  }
+  #  exec { "Add User - admin":
+  #  command     => "import-module servermanager;add-windowsfeature -name 'rsat-ad-powershell' -includeAllSubFeature;import-module activedirectory;New-ADUser -name 'Classroom Admin' -DisplayName 'Classroom Admin' -GivenName 'Classroom' -SurName 'Admin' -Email 'admin@CLASSROOM.local' -Samaccountname 'admin' -UserPrincipalName 'admin@CLASSROOM.local' -Description 'Classroom Administrator' -PasswordNeverExpires \$true -path 'OU=STUDENTS,DC=CLASSROOM,DC=local' -AccountPassword (ConvertTo-SecureString 'Adm1nP@SSw0rd' -AsPlainText -force) -Enabled \$true;",
+  #  onlyif      => "\$oustring = \"CN=Classroom Admin,OU=STUDENTS,DC=CLASSROOM,DC=local\"; if([adsi]::Exists(\"LDAP://\$oustring\")){exit 1}",
+  #  provider    => powershell,
+  #  require     => Exec['STUDENTS OU'],
+  #}
 
   # Download install for brackets lab
   class { 'staging':


### PR DESCRIPTION
This PR tackles using DSC for the windows class, primarily the classification of the ad server.  I've left the old execs present, but commented out.  They can be removed for cleanliness if prefferred.

I also updated the install_wmf5 script so it executes cleanly and uses the WMF 5.0 that is linked on the puppetlabs/dsc module's readme.

