### PR TITLE
Hotfix v1.7.5 pin powershell module to 2.0.3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 # pltraining/classroom
 ## Release Notes
 
+## v1.7.5
+* Pin powershell module to 2.0.3
+
 ## v1.7.4
 * Fix adserver code to use DSC and powershell5
 * Inherit params in hiera class

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "pltraining-classroom",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": "pltraining",
   "summary": "Manages Puppet Labs training classroom environments",
   "license": "Apache 2.0",
@@ -57,7 +57,7 @@
 
     {"name":"puppetlabs/acl",                 "version_requirement":">= 1.0.0"},
     {"name":"puppetlabs/dsc",                 "version_requirement":">= 1.0.0"},
-    {"name":"puppetlabs/powershell",          "version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs/powershell",          "version_requirement":"2.0.3"},
     {"name":"puppetlabs/reboot",              "version_requirement":">= 1.0.0"},
     {"name":"puppetlabs/registry",            "version_requirement":">= 1.0.0"},
     {"name":"puppetlabs/wsus_client",         "version_requirement":">= 1.0.0"},


### PR DESCRIPTION
Poweshell is showing incorrect exit codes in execs. Downgrading the
module to 2.0.3 fixed the issue, so this hotfix will do that. This
should be revisited later to see if the same issue comes up in later
releases of the powershell module.