### PR TITLE
Use the new simplified yum repositories on newer classroom VMs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -108,7 +108,20 @@ class classroom::params {
   }
 
   $repo_base_path = '/opt/puppetlabs/server/data/packages/public/yum'
-  $repos = {
-    'local'    => "/var/yum/mirror/",
+  
+  # Use the new simplified yum repositories on newer classroom VMs
+  if $::classroom_vm_release and versioncmp($::classroom_vm_release, '5.14') > 0 {
+    $repos = {
+      'local'    => "/var/yum/mirror/",
+    }
   }
+  else {
+   $repos = {
+     'base'    => "/var/yum/mirror/centos/${::operatingsystemmajrelease}/os/",
+     'extras'  => "/var/yum/mirror/centos/${::operatingsystemmajrelease}/extras/",
+     'updates' => "/var/yum/mirror/centos/${::operatingsystemmajrelease}/updates/",
+     'epel'    => "/var/yum/mirror/epel/${::operatingsystemmajrelease}/local/",
+    }
+  }
+  
 }


### PR DESCRIPTION
On older VMs, we'll want to pull from the old `localrepo` repositories.