### PR TITLE
Set default for control_owner to root

### DIFF
--- a/manifests/course/puppetize.pp
+++ b/manifests/course/puppetize.pp
@@ -1,6 +1,6 @@
 # This is a wrapper class to include all the bits needed for Puppetizing infrastructure
 class classroom::course::puppetize (
-  $control_owner,
+  $control_owner      = $classroom::params::control_owner,
   $offline            = $classroom::params::offline,
   $session_id         = $classroom::params::session_id,
   $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,

--- a/manifests/course/puppetize.pp
+++ b/manifests/course/puppetize.pp
@@ -4,6 +4,7 @@ class classroom::course::puppetize (
   $offline            = $classroom::params::offline,
   $session_id         = $classroom::params::session_id,
   $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  $use_gitea          = $classroom::params::use_gitea,
 ) inherits classroom::params {
   class { 'classroom::virtual':
     offline            => $offline,
@@ -23,7 +24,7 @@ class classroom::course::puppetize (
 
     $base_plugin_list = [ "Certificates", "Classification", "ConsoleUser", "Docker", "Logs", "Dashboard", "CodeManager", "ShellUser", "Gitviz" ]
 
-    if $offline {
+    if $use_gitea {
       $plugin_list = flatten([$base_plugin_list, "Gitea" ])
     } else {
       $plugin_list = $base_plugin_list
@@ -47,7 +48,7 @@ class classroom::course::puppetize (
     class { 'classroom::master::codemanager':
       control_owner => $control_owner,
       control_repo  => 'classroom-control-pi.git',
-      offline       => $offline,
+      use_gitea     => $use_gitea,
     }
 
   }

--- a/manifests/course/virtual/fundamentals.pp
+++ b/manifests/course/virtual/fundamentals.pp
@@ -1,5 +1,5 @@
 class classroom::course::virtual::fundamentals (
-  $control_owner,
+  $control_owner      = $classroom::params::control_owner,
   $offline            = $classroom::params::offline,
   $session_id         = $classroom::params::session_id,
   $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,

--- a/manifests/course/virtual/practitioner.pp
+++ b/manifests/course/virtual/practitioner.pp
@@ -1,5 +1,5 @@
 class classroom::course::virtual::practitioner (
-  $control_owner,
+  $control_owner      = $classroom::params::control_owner,
   $offline            = $classroom::params::offline,
   $session_id         = $classroom::params::session_id,
   $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,

--- a/manifests/master/codemanager.pp
+++ b/manifests/master/codemanager.pp
@@ -14,6 +14,10 @@ class classroom::master::codemanager (
       false => $classroom::params::gitserver['github'],
     }
 
+    if ($use_gitea) and ($control_owner != 'root') {
+      fail('Gitea requires the control_owner be set to "root"') 
+    }
+    
     pe_hocon_setting { 'enable code manager':
       ensure  => present,
       path    => '/etc/puppetlabs/enterprise/conf.d/common.conf',

--- a/manifests/master/codemanager.pp
+++ b/manifests/master/codemanager.pp
@@ -14,10 +14,10 @@ class classroom::master::codemanager (
       false => $classroom::params::gitserver['github'],
     }
 
-    if ($use_gitea) and ($control_owner != 'root') {
-      fail('Gitea requires the control_owner be set to "root"') 
+    if ($use_gitea) and ($control_owner != $classroom::params::control_owner) {
+      fail('Control owner cannot be set when using gitea') 
     }
-    if ($use_gitea == false) and ($control_owner == 'root') {
+    if ($use_gitea == false) and ($control_owner == $classroom::params::control_owner) {
       fail('control_owner is a required parameter for trainings using github')
     }
     

--- a/manifests/master/codemanager.pp
+++ b/manifests/master/codemanager.pp
@@ -17,6 +17,9 @@ class classroom::master::codemanager (
     if ($use_gitea) and ($control_owner != 'root') {
       fail('Gitea requires the control_owner be set to "root"') 
     }
+    if ($use_gitea == false) and ($control_owner == 'root') {
+      fail('control_owner is a required parameter for trainings using github')
+    }
     
     pe_hocon_setting { 'enable code manager':
       ensure  => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,9 @@ class classroom::params {
   # Use the gitea git server
   $use_gitea = false
 
+  # Default to root for gitea
+  $control_owner = 'root'
+
   if $::osfamily == 'windows' {
     # Path to the student's working directory
     $workdir = 'C:/puppetcode'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,6 @@ class classroom::params {
 
   # git configuration for the web-based alternative git workflow
   $usersuffix       = 'puppetlabs.vm'
-  $control_owner    = 'puppetlabs-education'
   $repo_model       = 'single'
   $gitserver        = {
     'github'  => 'https://github.com',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@ class classroom::params {
   $offline   = false
 
   # Use the gitea git server
-  $use_gitea = false
+  $use_gitea = true
 
   # Default to root for gitea
   $control_owner = 'root'

--- a/spec/classes/course/virtual/fundamentals_spec.rb
+++ b/spec/classes/course/virtual/fundamentals_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe 'classroom::course::virtual::fundamentals' do
 
   parameter_matrix = [
-    { :offline => true, :control_owner => 'puppetlabs-education' },
-    { :offline => false, :control_owner => 'puppetlabs-education' }
+    {},
+    { :offline => true, },
+    { :offline => false, :control_owner => 'puppetlabs-education', :use_gitea => false }
   ]
   parameter_matrix.each do |params|
     context "applied to master: #{params.to_s}" do

--- a/spec/classes/course/virtual/practitioner_spec.rb
+++ b/spec/classes/course/virtual/practitioner_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe 'classroom::course::virtual::practitioner' do
 
   parameter_matrix = [
-    { :offline => true, :control_owner => 'puppetlabs-education' },
-    { :offline => false, :control_owner => 'puppetlabs-education' }
+    { },
+    { :offline => true},
+    { :offline => false, :control_owner => 'puppetlabs-education', :use_gitea => false }
   ]
   parameter_matrix.each do |params|
     context "applied to master: #{params.to_s}" do


### PR DESCRIPTION
Gitea uses the "root" user to set up the control repo, this makes that the default and will throw an error if someone tries to use gitea with another control_repo.