### PR TITLE
(TRAINTECH-1133) Replace general contribution guidelines with link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,7 @@
-# How to contribute
+Contribution Guidelines
+=======================
+
+## How to contribute
 
 This module was developed in to support Puppet training. It is open to
 the public so that students can see the code that goes in to creating
@@ -10,80 +13,10 @@ code may not be accepted.
 Priority will be given to contributions from Puppet Professional Services
 engineers and Service Delivery Partners actively teaching classes.
 
-There are a few guidelines that we need contributors to follow so that 
-we can have a chance of keeping on top of things.
-
-## Getting Started
-
-* Make sure you have a [Jira account](https://tickets.puppetlabs.com)
-* Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a ticket for your issue, assuming one does not already exist.
-  * Clearly describe the issue including steps to reproduce when it is a bug.
-  * Make sure you fill in the earliest version that you know has the issue.
-* Fork the repository on GitHub
-
-## Making Changes
-
-Releases are made from the `release` branch, which should always be in a
-releasable state. `master` is the active development branch and changes 
-are periodically moved to the release branch for acceptance testing.
-
-Before you begin working on an issue or feature, check that it hasn't
-already been addressed in the `master` branch.
-
-* Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
-  * Only target release branches if you are certain your fix must be on that
-    branch.
-  * To quickly create a topic branch based on master; `git checkout -b
-    fix/master/my_contribution master`. Please avoid working directly on the
-    `master` branch.
-* Make atomic commits of logical units. Do not combine unrelated fixes.
-* Check for unnecessary whitespace with `git diff --check` before committing.
-* Make sure your commit messages are in the proper format.
-* Don't update version numbers or changelogs. Instead, write a good commit 
-  subject and description. We will use the commit subject to update the 
-  changelog as needed.
-
-````
-    (PUP-1234) Make the example in CONTRIBUTING imperative and concrete
-
-    Without this patch applied the example commit message in the CONTRIBUTING
-    document is not a concrete example.  This is a problem because the
-    contributor is left to imagine what the commit message should look like
-    based on a description rather than an example.  This patch fixes the
-    problem by making the example concrete and imperative.
-
-    The first line is a real life imperative statement with a ticket number
-    from our issue tracker.  The body describes the behavior without the patch,
-    why this is a problem, and how the patch fixes the problem when applied.
-````
-
-* Make sure you have added the necessary tests for your changes.
-* Run _all_ the tests to assure nothing else was accidentally broken.
-  * Tests can be run with the command `rake spec`
-
-## Making Trivial Changes
-
-### Documentation
-
-For changes of a trivial nature to comments and documentation, it is not
-always necessary to create a new ticket in Jira. In this case, it is
-appropriate to start the first line of a commit with '(doc)' instead of
-a ticket number.
-
-````
-    (doc) Add documentation commit example to CONTRIBUTING
-
-    There is no example for contributing a documentation commit
-    to the Puppet repository. This is a problem because the contributor
-    is left to assume how a commit of this nature may appear.
-
-    The first line is a real life imperative statement with '(doc)' in
-    place of what would have been the ticket number in a
-    non-documentation related commit. The body describes the nature of
-    the new documentation or comments added.
-````
+Please refer to our [contribution
+guidelines](https://github.com/puppetlabs/edu-documentation/blob/master/CONTRIBUTING.md)
+documentation for general information on contributing to Puppet Education
+projects.
 
 ## Submitting Changes
 


### PR DESCRIPTION
To ensure a consistent and well-documented contribution process across
Puppet Education project repositories, general contribution guidelines
here are replaced to a link to the common contribution guidelines in
the edu-documentation repository.

Guidelines specific to this repository have been preserved here.