### PR TITLE
Ensure all nodes have pe-puppet

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -23,6 +23,11 @@ class classroom::agent {
     }
   }
 
+  # ensure all nodes have this user, since it's used for file ownership in places
+  user { 'pe-puppet':
+    ensure => present,
+  }
+
   # make sure our git environment is set up and usable
   include classroom::agent::git
 

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -70,6 +70,11 @@ class classroom::virtual (
     include classroom::proxy
 
   } else {
+    # ensure all nodes have this user, since it's used for file ownership in places
+    user { 'pe-puppet':
+      ensure => present,
+    }
+
     # if we ever have universal classification for virtual agents, it will go here
     include classroom::agent::hiera
     include classroom::agent::packages


### PR DESCRIPTION
The user is required because some files are placed into the `codedir`
and the `puppet_enterprise` module now chowns them on each run if
they're not already owned by `pe-puppet`.

TRAINTECH-1352 #resolved #time 30m