### PR TITLE
Add ssh key so student can log in directly

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -42,6 +42,9 @@ class classroom::agent {
   # Configure basemodulepath for online or offline instruction
   include classroom::agent::modulecache
 
+  # set up the ssh authorization for the training user
+  include classroom::agent::sshauth
+
   # export a classroom::user with our ssh key.
   #
   # !!!! THIS MAY EXPORT AN EMPTY KEY ON THE FIRST RUN !!!!

--- a/manifests/agent/sshauth.pp
+++ b/manifests/agent/sshauth.pp
@@ -1,0 +1,11 @@
+class classroom::agent::sshauth {
+
+  # The public half of this key is on the Downloads page of the Courseware presentation
+  ssh_authorized_key { 'training@puppet.com':
+    ensure => present,
+    user   => 'training',
+    type   => 'ssh-rsa',
+    key    => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDT4hxLhcccJhKRHp5uSEpmE3EgXaOlL72qI7T8cJOh/hov/MsCd8IVGc1fE1romqCjS6vITn9L/tPeJOwmGSih0iUWEQd6CY/OZttdnlelwaGke12hPiuqYqEqGcExNrGoynTQWMz99T6cdyd9HptCGdYGK1EwCi3hmv9QBZGChUbnQKqi3Zc1Uubpzp6WyTXaDoxLxlxX7QXt8K7cRaAviDZ/I07svoO9RwZPqGyeeyh4k1pAYTik8jY58rMmDCNcp6jM4AWAF786k77GI/DBzACJ7kt1Qe8fGLlm7UyV/nSZhxiKs3TcfqBypPf+tQzvfvSfRdVvoMQQOw38ogqT',
+  }
+
+}

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -79,6 +79,7 @@ class classroom::virtual (
     include classroom::agent::hiera
     include classroom::agent::packages
     include classroom::agent::rubygems
+    include classroom::agent::sshauth
 
     unless $osfamily == 'windows' {
       include classroom::agent::postfix_ipv4


### PR DESCRIPTION
This just gives the training user an ssh key so that students can log in
directly once they have the private half. That will be distributed in
the courseware.

COURSES-3198 #resolved #time 45m