### PR TITLE
Simplify Hiera setup a little bit

### DIFF
--- a/files/hiera/data/classroom.yaml
+++ b/files/hiera/data/classroom.yaml
@@ -1,6 +1,7 @@
 ---
-puppet_enterprise::profile::console::rbac_session_timeout: 4320
-puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'
 pe_repo::compile_master_pool_address: 'https://master.puppetlabs.vm'
 puppet_enterprise::master::puppetserver::jruby_environment_class_cache_enabled: true
 puppet_enterprise::profile::console::classifier_synchronization_period: 300
+puppet_enterprise::profile::console::proxy::http_redirect::enable_http_redirect: false
+puppet_enterprise::profile::console::rbac_session_timeout: 4320
+puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'

--- a/manifests/master/hiera.pp
+++ b/manifests/master/hiera.pp
@@ -13,6 +13,8 @@ class classroom::master::hiera {
 
   # Because PE writes a default, we have to do tricks to see if we've already managed this.
   # We don't want to stomp on instructors doing demonstrations.
+  # TODO: manage unconditionally as soon as we get Hiera 5 excercises. We'll demo
+  #       with environment hiera.yamls.
   unless defined('$puppetlabs_class') {
     file { "${classroom::params::confdir}/hiera.yaml":
       ensure  => file,
@@ -34,16 +36,17 @@ class classroom::master::hiera {
     target => "${classroom::params::codedir}/environments",
   }
 
-  file { "${hieradata}/common.yaml":
-    ensure  => file,
-    source  => 'puppet:///modules/classroom/hiera/data/common.yaml',
-    replace => false,
-  }
-
-  # classroom parameters
+  # classroom parameters: if the instructor must override these for some reason
+  #                       they can use the `overrides` level.
   file { "${hieradata}/classroom.yaml":
     ensure  => file,
     source  => 'puppet:///modules/classroom/hiera/data/classroom.yaml',
+  }
+
+  # This is designed for editing during classroom demos. Don't overwrite it.
+  file { "${hieradata}/common.yaml":
+    ensure  => file,
+    source  => 'puppet:///modules/classroom/hiera/data/common.yaml',
     replace => false,
   }
 

--- a/templates/hiera/data/tuning.yaml.erb
+++ b/templates/hiera/data/tuning.yaml.erb
@@ -1,6 +1,4 @@
 ---
-puppet_enterprise::profile::console::proxy::http_redirect::enable_http_redirect: false
-<% if @jvm_tuning_profile != false -%>
 puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'
 puppet_enterprise::profile::amq::broker::heap_mb: '<%= @amq_heap_mb %>'
 puppet_enterprise::profile::master::java_args:
@@ -27,5 +25,4 @@ puppet_enterprise::profile::console::classifier_synchronization_period: <%= @con
 puppet_enterprise::profile::orchestrator::java_args:
   Xms: <%= @orch_Xms %>
   Xmx: <%= @orch_Xmx %>
-<% end -%>
 <% end -%>


### PR DESCRIPTION
This makes it more straightforward what's configured & where. It doesn't
fix the fact that the hiera.yaml won't be fixed if it gets corrupted,
but that will take courseware changes before we can manage it
unconditionally.

TRAINTECH-1397 #resolved #time 90m