### PR TITLE
(maint) a better check for CM

### DIFF
--- a/lib/facter/code_manager.rb
+++ b/lib/facter/code_manager.rb
@@ -1,0 +1,5 @@
+Facter.add('code_manager_enabled') do
+  setcode do
+    File.file?('/etc/puppetlabs/puppetserver/conf.d/code-manager.conf')
+  end
+end

--- a/manifests/master/deployer.pp
+++ b/manifests/master/deployer.pp
@@ -18,24 +18,25 @@ class classroom::master::deployer (
     provider => 'posix',
     require  => Rbac_user['deployer'],
   }
-  
-  file { '/etc/puppetlabs/code-staging/.deployed':
-    ensure => file,
-    owner  => 'pe-puppet',
-    group  => 'pe-puppet',
-    mode   => '0644',
-    before => Exec['deploy codebase'],
+
+  if $::code_manager_enabled {
+    file { '/etc/puppetlabs/code-staging/.deployed':
+      ensure => file,
+      owner  => 'pe-puppet',
+      group  => 'pe-puppet',
+      mode   => '0644',
+      before => Exec['deploy codebase'],
+    }
+
+    # We run the deploy command on each Puppet run until the deployment succeeds.
+    # This should never show up as a failed run.
+    exec { 'deploy codebase':
+      command => 'puppet code deploy --all --wait',
+      path    => '/bin:/usr/bin:/opt/puppetlabs/bin',
+      creates => '/etc/puppetlabs/code/.deployed',
+      returns => [ 0, 1 ], # we "don't care" if it succeeds, just keep trying until it deploys
+      require => Exec['create token'],
+    }
   }
 
-  # We run the deploy command on each Puppet run until Code Manager enables itself and the deployment succeeds.
-  # This should never show up as a failed run.
-  exec { 'deploy codebase':
-    command => 'puppet code deploy --all --wait',
-    path    => '/bin:/usr/bin:/opt/puppetlabs/bin',
-    creates => '/etc/puppetlabs/code/.deployed',
-    returns => [ 0, 1 ], # we "don't care" if it succeeds, just keep trying until it deploys
-    require => Exec['create token'],
-  }
-  
 }
-


### PR DESCRIPTION
This waits to attempt a deploy until CM is enabled. Without this, every
run in ILT will show as changed.