### PR TITLE
Removes the non-gitea options

### DIFF
--- a/manifests/course/puppetize.pp
+++ b/manifests/course/puppetize.pp
@@ -1,19 +1,15 @@
-# This is a wrapper class to include all the bits needed for Puppetizing infrastructure
+# typing the parameters doesn't actually gain us anything, since the
+# Console doesn't provide any hinting. Subclasses validate types.
 class classroom::course::puppetize (
-  $control_owner      = $classroom::params::control_owner,
-  $offline            = $classroom::params::offline,
-  $session_id         = $classroom::params::session_id,
-  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
-  $use_gitea          = $classroom::params::use_gitea,
   $event_id           = undef,
   $event_pw           = undef,
+  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  $offline            = $classroom::params::offline,
   $version            = undef,
 ) inherits classroom::params {
   class { 'classroom::virtual':
     offline            => $offline,
-    use_gitea          => $use_gitea,
     jvm_tuning_profile => $jvm_tuning_profile,
-    control_owner      => $control_owner,
     control_repo       => 'classroom-control-pi.git',
     event_id           => $event_id,
     event_pw           => $event_pw,

--- a/manifests/course/virtual/fundamentals.pp
+++ b/manifests/course/virtual/fundamentals.pp
@@ -1,18 +1,15 @@
+# typing the parameters doesn't actually gain us anything, since the
+# Console doesn't provide any hinting. Subclasses validate types.
 class classroom::course::virtual::fundamentals (
-  $control_owner      = $classroom::params::control_owner,
-  $offline            = $classroom::params::offline,
-  $session_id         = $classroom::params::session_id,
-  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
-  $use_gitea          = $classroom::params::use_gitea,
   $event_id           = undef,
   $event_pw           = undef,
+  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  $offline            = $classroom::params::offline,
   $version            = undef,
 ) inherits classroom::params {
   class { 'classroom::virtual':
     offline            => $offline,
-    use_gitea          => $use_gitea,
     jvm_tuning_profile => $jvm_tuning_profile,
-    control_owner      => $control_owner,
     control_repo       => 'classroom-control-vf.git',
     event_id           => $event_id,
     event_pw           => $event_pw,

--- a/manifests/course/virtual/intro.pp
+++ b/manifests/course/virtual/intro.pp
@@ -1,17 +1,15 @@
+# typing the parameters doesn't actually gain us anything, since the
+# Console doesn't provide any hinting. Subclasses validate types.
 class classroom::course::virtual::intro (
-  $control_owner      = $classroom::params::control_owner,
-  $offline            = $classroom::params::offline,
-  $session_id         = $classroom::params::session_id,
-  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
   $event_id           = undef,
   $event_pw           = undef,
+  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  $offline            = $classroom::params::offline,
   $version            = undef,
 ) inherits classroom::params {
   class { 'classroom::virtual':
     offline            => $offline,
-    use_gitea          => true,
     jvm_tuning_profile => $jvm_tuning_profile,
-    control_owner      => $control_owner,
     control_repo       => 'classroom-control-intro.git',
     event_id           => $event_id,
     event_pw           => $event_pw,

--- a/manifests/course/virtual/parser.pp
+++ b/manifests/course/virtual/parser.pp
@@ -1,17 +1,15 @@
+# typing the parameters doesn't actually gain us anything, since the
+# Console doesn't provide any hinting. Subclasses validate types.
 class classroom::course::virtual::parser (
-  $control_owner      = $classroom::params::control_owner,
-  $offline            = $classroom::params::offline,
-  $session_id         = $classroom::params::session_id,
-  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
   $event_id           = undef,
   $event_pw           = undef,
+  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  $offline            = $classroom::params::offline,
   $version            = undef,
 ) inherits classroom::params {
   class { 'classroom::virtual':
     offline            => $offline,
-    use_gitea          => true,
     jvm_tuning_profile => $jvm_tuning_profile,
-    control_owner      => $control_owner,
     control_repo       => 'classroom-control-p4.git',
     event_id           => $event_id,
     event_pw           => $event_pw,

--- a/manifests/course/virtual/practitioner.pp
+++ b/manifests/course/virtual/practitioner.pp
@@ -1,18 +1,15 @@
+# typing the parameters doesn't actually gain us anything, since the
+# Console doesn't provide any hinting. Subclasses validate types.
 class classroom::course::virtual::practitioner (
-  $control_owner      = $classroom::params::control_owner,
-  $offline            = $classroom::params::offline,
-  $session_id         = $classroom::params::session_id,
-  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
-  $use_gitea          = $classroom::params::use_gitea,
   $event_id           = undef,
   $event_pw           = undef,
+  $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  $offline            = $classroom::params::offline,
   $version            = undef,
 ) inherits classroom::params {
   class { 'classroom::virtual':
     offline            => $offline,
-    use_gitea          => $use_gitea,
     jvm_tuning_profile => $jvm_tuning_profile,
-    control_owner      => $control_owner,
     control_repo       => 'classroom-control-vp.git',
     event_id           => $event_id,
     event_pw           => $event_pw,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class classroom::params {
   $session_id    = '12345'
 
   # Default plugin list for Puppetfactory classes
-  $plugin_list   = [ "Certificates", "Classification", "ConsoleUser", "Docker", "Logs", "Dashboard", "CodeManager", "ShellUser" ]
+  $plugin_list   = [ "Certificates", "Classification", "ConsoleUser", "Docker", "Logs", "Dashboard", "CodeManager", "Gitea", "ShellUser" ]
 
   # Showoff and printing stack configuration
   $training_user  = 'training'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,9 +2,6 @@ class classroom::params {
   # Configure NTP (and other services) to run in standalone mode
   $offline   = false
 
-  # Use the gitea git server
-  $use_gitea = true
-
   # Default to root for gitea
   $control_owner = 'root'
 
@@ -41,12 +38,9 @@ class classroom::params {
   $manage_repos = true
 
   # git configuration for the web-based alternative git workflow
-  $usersuffix       = 'puppetlabs.vm'
-  $repo_model       = 'single'
-  $gitserver        = {
-    'github'  => 'https://github.com',
-    'gitea' => 'http://master.puppetlabs.vm:3000',
-  }
+  $usersuffix   = 'puppetlabs.vm'
+  $repo_model   = 'single'
+  $gitserver    = 'http://master.puppetlabs.vm:3000'
 
   # time servers to use if we've got network
   $time_servers = ['0.pool.ntp.org iburst', '1.pool.ntp.org iburst', '2.pool.ntp.org iburst', '3.pool.ntp.org']

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -1,19 +1,18 @@
 # common configuration for all virtual classes
 class classroom::virtual (
-  String                            $control_repo,
-  String                            $control_owner,
-  Optional[String]                  $event_id           = undef,
-  Optional[String]                  $event_pw           = undef,
-  Boolean                           $offline            = $classroom::params::offline,
-  Boolean                           $use_gitea          = $classroom::params::use_gitea,
-  Array                             $plugin_list        = $classroom::params::plugin_list,
-  Variant[Enum['reduced'], Boolean] $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  String                                  $control_repo,
+  Optional[Pattern[/\A(?:\w*-)+(\w*)\Z/]] $event_id           = undef,
+  Optional[String]                        $event_pw           = undef,
+  Variant[Enum['reduced'], Boolean]       $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
+  Boolean                                 $offline            = $classroom::params::offline,
+  Array                                   $plugin_list        = $classroom::params::plugin_list,
 ) inherits classroom::params {
   assert_private('This class should not be called directly')
 
   if $classroom::params::role == 'master' {
     include showoff
     include classroom::master::dependencies::rubygems
+    include classroom::master::dependencies::dashboard
 
     # Configure Hiera and install a Hiera data file to tune PE
     class { 'classroom::master::tuning':
@@ -29,33 +28,13 @@ class classroom::virtual (
     # Set up gitea server
     include classroom::master::gitea
 
-    if $offline or $use_gitea {
-      $full_plugin_list = flatten([$plugin_list, "Gitea" ])
-      $gitserver        = $classroom::params::gitserver['gitea']
-
-      if($control_owner != $classroom::params::control_owner) {
-        fail('Control owner cannot be set when using gitea')
-      }
-    } else {
-      $full_plugin_list = $plugin_list
-      $gitserver        = $classroom::params::gitserver['github']
-
-      if($control_owner == $classroom::params::control_owner) {
-        fail('control_owner is a required parameter for trainings using github')
-      }
-    }
-
     $session_id = pick($event_pw, regsubst(String($event_id), '^(?:\w*-)+(\w*)$', '\1'), $classroom::params::session_id)
 
-    if 'Dashboard' in $full_plugin_list {
-      include classroom::master::dependencies::dashboard
-    }
-
     class { 'puppetfactory':
-      plugins          => $full_plugin_list,
-      gitserver        => $gitserver,
       controlrepo      => $control_repo,
-      repomodel        => 'single',
+      plugins          => $plugin_list,
+      gitserver        => $classroom::params::gitserver,
+      repomodel        => $classroom::params::repo_model,
       usersuffix       => $classroom::params::usersuffix,
       dashboard_path   => "${showoff::root}/courseware/_files/tests",
       session          => $session_id,
@@ -64,9 +43,7 @@ class classroom::virtual (
     }
 
     class { 'classroom::master::codemanager':
-      control_owner => $control_owner,
-      control_repo  => $control_repo,
-      gitserver     => $gitserver,
+      control_repo => $control_repo,
     }
 
   } elsif $classroom::params::role == 'proxy' {

--- a/spec/classes/course/puppetize_spec.rb
+++ b/spec/classes/course/puppetize_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'classroom::course::virtual::practitioner' do
+describe 'classroom::course::puppetize' do
 
   parameter_matrix = [
     { :offline => true},

--- a/spec/classes/course/virtual/fundamentals_spec.rb
+++ b/spec/classes/course/virtual/fundamentals_spec.rb
@@ -4,8 +4,7 @@ describe 'classroom::course::virtual::fundamentals' do
 
   parameter_matrix = [
     { :offline => true},
-    { :offline => false, :use_gitea => true },
-    { :offline => false, :use_gitea => false, :control_owner => 'puppetlabs-education', },
+    { :offline => false},
   ]
   parameter_matrix.each do |params|
     context "applied to master: #{params.to_s}" do


### PR DESCRIPTION
We've consolidated to using Gitea across the board. This codifies that
and removes the number of variations we need to test & validate. It also
simplifies the experience for the instructor, since they're not
presented with unclear configuration options.

This also adds a spec for puppetize, since its configuration is slightly
different from the other virtuals.

TRAINTECH-1445 #resolved #time 2h