### PR TITLE
Install chocolatey properly for windows clients

### DIFF
--- a/manifests/agent/git.pp
+++ b/manifests/agent/git.pp
@@ -19,20 +19,19 @@ class classroom::agent::git {
   }
 
   if $::osfamily == 'windows'{
-    require chocolatey
+    require classroom::windows
 
     package { ['git', 'kdiff3']:
       ensure   => present,
       provider => 'chocolatey',
       before   => [ File[$sshpath], Exec['generate_key'] ],
-      require  => Package['chocolatey'],
     }
 
     file { 'C:/Users/Administrator/.ssh/':
       ensure  => directory,
       source  => $sshpath,
       recurse => true,
-      require => [File[$sshpath],Exec['generate_key'],User['Administrator']],
+      require => [ File[$sshpath], Exec['generate_key'] ],
     }
 
     windows_env { 'PATH=C:\Program Files\Git\bin': }

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -81,26 +81,7 @@ class classroom::virtual (
   }
 
   if $::osfamily == 'windows' {
-    # TODO: copied from classroom::windows; we should refactor both classes for reusability
-    user { 'Administrator':
-      ensure => present,
-      groups => ['Administrators'],
-    }
-
-    chocolateyfeature { 'allowEmptyChecksums':
-      ensure => enabled,
-    }
-    Chocolateyfeature['allowEmptyChecksums'] -> Package<| provider == 'chocolatey' |>
-
-    # Windows Agents
-    class {'chocolatey':
-      chocolatey_download_url => 'https://chocolatey.org/api/v2/package/chocolatey/0.10.3',
-    }
-
-    include classroom::windows::disable_esc
-    include classroom::windows::enable_rdp
-    include classroom::windows::geotrust
-    windows_env { 'PATH=C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin': }
+    include classroom::windows
   }
 
   # fix augeas lens until it's updated in PE

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -1,23 +1,34 @@
 class classroom::windows {
   assert_private('This class should not be called directly')
 
+  require chocolatey
+
   include classroom::windows::geotrust
   include classroom::windows::password_policy
   include classroom::windows::disable_esc
   include classroom::windows::alias
+  include classroom::windows::enable_rdp
 
   include userprefs::npp
+
+  # Just a sanity check here. Some of the platforms we use don't have Admin by default.
+  user { 'Administrator':
+    ensure => present,
+    groups => ['Administrators'],
+  }
+
+  windows_env { 'PATH=C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin': }
+
+  # Not all choco packages we use have been updated with checksums
+  chocolateyfeature { 'allowEmptyChecksums':
+    ensure => enabled,
+  }
+  Chocolateyfeature['allowEmptyChecksums'] -> Package<| provider == 'chocolatey' |>
 
   package { ['console2', 'putty', 'unzip', 'devbox-common.extension']:
     ensure   => present,
     provider => 'chocolatey',
     require  => [ Class['chocolatey'], Package['chocolatey'] ],
-  }
-
-  package { 'chocolatey':
-    ensure   => latest,
-    provider => 'chocolatey',
-    require  => Class['chocolatey'],
   }
 
   ini_setting { 'certname':


### PR DESCRIPTION
This allows windows clients to install chocolatey properly and creates
relationships appropriately so that subclasses compile properly

We need to add windows agents to the testing suite so this doesn't
happen again. Ticket filed.

TRAINTECH-1503 #resolved #time 1h