### PR TITLE
Removed bad relationship in adserver

### DIFF
--- a/manifests/windows/adserver.pp
+++ b/manifests/windows/adserver.pp
@@ -14,7 +14,6 @@ class classroom::windows::adserver (
 	package { 'powershell':
   	ensure => '5.1.14409.20170510',
   	provider => 'chocolatey',
-  	require => Package['chocolatey'],
   }
 
 	# We need a reboot before DSC can use WMF5.

--- a/spec/classes/course/puppetize_spec.rb
+++ b/spec/classes/course/puppetize_spec.rb
@@ -62,5 +62,26 @@ describe 'classroom::course::puppetize' do
 #       it { should compile }
 #     end
 
+#     context "applied to Windows AD server: #{params.to_s}" do
+#       let(:pre_condition) {
+#         "$puppetmaster = 'master.puppetlabs.vm'
+#          $ec2_metadata = undef
+#          service { 'pe-puppetserver':
+#            ensure => running,
+#          }" + GLOBAL_PRE
+#       }
+#       let(:node) { 'adserver.puppetlabs.vm' }
+#       let(:facts) { {
+#         :osfamily           => 'windows',
+#         :operatingsystem    => 'windows',
+#         :servername         => 'master.puppetlabs.vm',
+#         :choco_install_path => 'C:\ProgramData\chocolatey',
+#         :chocolateyversion  => '0.10.3',
+#       } }
+#       let(:params) { params }
+#
+#       it { should compile }
+#     end
+
   end
 end


### PR DESCRIPTION
Because the windows class already requires the chocolatey class, this
relationship isn't even needed.

Still can't use the spec test, so still commented out...

TRAINTECH-1592 #resolved #time 15m