### PR TITLE
Accept non-hyphenated event IDs

### DIFF
--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -1,7 +1,7 @@
 # common configuration for all virtual classes
 class classroom::virtual (
   String                                  $control_repo,
-  Optional[Pattern[/\A(?:\w*-)+(\w*)\Z/]] $event_id           = undef,
+  Optional[Pattern[/\A(?:\w*-)*(\w*)\Z/]] $event_id           = undef,
   Optional[String]                        $event_pw           = undef,
   Variant[Enum['reduced'], Boolean]       $jvm_tuning_profile = $classroom::params::jvm_tuning_profile,
   Boolean                                 $offline            = $classroom::params::offline,


### PR DESCRIPTION
This allows Event IDs without a hyphen. All these will now work:

* TEST
* TEST12345678
* TEST1234-5678
* TEST-1234-5678

TRAINTECH-1577 #resolved #time 30m