### PR TITLE
Port to puppet/archive

### DIFF
--- a/manifests/windows/adserver.pp
+++ b/manifests/windows/adserver.pp
@@ -91,12 +91,9 @@ class classroom::windows::adserver (
     ensure => directory,
   }
 
-  class { 'staging':
-    path    => 'C:/shares',
-  }
-  staging::file { 'Brackets.msi':
+  archive { 'C:/shares/Brackets.msi':
     source  => 'https://github.com/adobe/brackets/releases/download/release-1.3/Brackets.Release.1.3.msi',
-    require => Class['staging'],
+    require => File['C:/shares'],
   }
 
   # Windows file share for UNC lab
@@ -104,7 +101,7 @@ class classroom::windows::adserver (
   fileshare { 'installer':
     ensure  => present,
     path    => 'C:/shares/classroom',
-    require => Class['staging'],
+    require => File['C:/shares/classroom'],
   }
 
   acl { 'c:/shares/classroom/Brackets.msi':

--- a/manifests/windows/adserver.pp
+++ b/manifests/windows/adserver.pp
@@ -91,9 +91,9 @@ class classroom::windows::adserver (
     ensure => directory,
   }
 
-  archive { 'C:/shares/Brackets.msi':
+  archive { 'C:/shares/classroom/Brackets.msi':
     source  => 'https://github.com/adobe/brackets/releases/download/release-1.3/Brackets.Release.1.3.msi',
-    require => File['C:/shares'],
+    require => File['C:/shares/classroom'],
   }
 
   # Windows file share for UNC lab

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     {"name":"puppetlabs/powershell",          "version_requirement":">= 2.0.0"},
     {"name":"puppetlabs/reboot",              "version_requirement":">= 1.0.0"},
     {"name":"puppetlabs/registry",            "version_requirement":">= 1.0.0"},
-    {"name":"puppet/staging",                 "version_requirement":">= 2.0.1"},
+    {"name":"puppet/archive",                 "version_requirement":">= 2.1.0"},
     {"name":"badgerious/windows_env",         "version_requirement":">= 2.0.0"},
     {"name":"puppet/windowsfeature",          "version_requirement":">= 1.0.0"},
 


### PR DESCRIPTION
The staging module has been deprecated for a rather long time. I don't
know for sure that simply porting will resolve the TLS issue, but it's
worth a shot. If we have to make upstream fixes, they'll be accepted
into this module, but not the other.

TRAINTECH-1597 #time 1h