### PR TITLE
Pin specinfra to 2.74.0

### DIFF
--- a/manifests/master/dependencies/rubygems.pp
+++ b/manifests/master/dependencies/rubygems.pp
@@ -30,6 +30,10 @@ class classroom::master::dependencies::rubygems {
     ensure   => '1.8.0',
     provider => gem,
   }
+  package { 'specinfra':
+    ensure   => '2.74.0',
+    provider => gem,
+  }
 
   # This is a soft relationship. It won't fail if showoff isn't included.
   Package['nokogiri']      -> Package<| title == 'showoff' |>


### PR DESCRIPTION
In order to resolve the issues with specinfra (which serverspec depends
on) requiring net-ssh 5.x which requires >= ruby 2.2.6; Pinning
specinfra to 2.74.0.  Without this commit classroom standup fails.