### PR TITLE
Removing specinfra changes and release 2.0.3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,5 @@
 # pltraining/classroom
 ## Release Notes
-## v2.0.3
-* ipcrm: Pinning specinfra to 2.74.0 to solve for the net-ssh 5.x ruby >= 2.2.6 issue
-
 ## v2.0.2
 
 ## v2.0.1

--- a/manifests/master/dependencies/rubygems.pp
+++ b/manifests/master/dependencies/rubygems.pp
@@ -30,11 +30,6 @@ class classroom::master::dependencies::rubygems {
     ensure   => '1.8.0',
     provider => gem,
   }
-  package { 'specinfra':
-    ensure   => '2.74.0',
-    provider => gem,
-  }
-
   # This is a soft relationship. It won't fail if showoff isn't included.
   Package['nokogiri']      -> Package<| title == 'showoff' |>
   Package['public_suffix'] -> Package<| title == 'showoff' |>

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "pltraining-classroom",
-  "version": "2.0.3",
+  "version": "2.0.2",
   "author": "pltraining",
   "summary": "Manages Puppet Labs training classroom environments",
   "license": "Apache 2.0",


### PR DESCRIPTION
The specinfra changes (as it turns out) needed to go into
pltraining-boostrap.  There is no need for a 2.0.3 release.  Removed
from the forge, removed the tag in GH.